### PR TITLE
Change the way of identifying mutau channel skims

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the code to suit your needs).
 
 To run in interactive mode for example:
 ```
-SVFitStandAloneFSATauDM inputFile=coolInputFile.root newOutputFile=1 newFile=tmpOut.root doES=1 metType=-1 
+SVFitStandAloneFSATauDM inputFile=coolInputFile.root newFile=tmpOut.root doES=1 isWJets=0 metType=-1 
 ```
 
  - inputFile = obvious

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the code to suit your needs).
 
 To run in interactive mode for example:
 ```
-SVFitStandAloneFSATauDM inputFile=coolInputFile.root newOutputFile=1 newFile=tmpOut.root doES=1 metType=-1 recoilType=0
+SVFitStandAloneFSATauDM inputFile=coolInputFile.root newOutputFile=1 newFile=tmpOut.root doES=1 metType=-1 
 ```
 
  - inputFile = obvious
@@ -30,10 +30,6 @@ SVFitStandAloneFSATauDM inputFile=coolInputFile.root newOutputFile=1 newFile=tmp
  - doES = apply energy scale adjustments providing nominal, shift UP and shift DOWN values of svFit
    - 0 = default, no shift
    - 1 = apply shifts
- - recoilType = type of recoile correction based on generator, MadGraph or amc@nlo
-   - 0 = no recoil corrections (for all non-DYJets/WJets/Higgs samples)
-   - 1 = amc@nlo recoil corrections
-   - 2 = MadGraph recoil corrections
  - isWJets = this shifts the number of jets used in recoil corrections, it is critical for
 WJets samples because we clear our jets to preven overlapping with out leptons, but
 with WJets one of the leptons is a jet
@@ -46,7 +42,7 @@ with WJets one of the leptons is a jet
 To submit jobs to condor:
 ```
 cd test
-python svFitSubmitter.py -dr -sd directoryOfCoolFiles -es=1 -r=2 -iswj=0 -mt=-1 --jobName svFitForWin
+python svFitSubmitter.py -dr -sd directoryOfCoolFiles -es=1 -iswj=0 -mt=-1 --jobName svFitForWin
 ```
 
  - -dr = dryRun and outputs a command for you to run
@@ -54,7 +50,6 @@ python svFitSubmitter.py -dr -sd directoryOfCoolFiles -es=1 -r=2 -iswj=0 -mt=-1 
        you must have your files in a /hdfs directory.
  - -es = apply energy scale, see above
  - --jobName = applys a job name to append to your file names and output directory structure
- - -r = recoileType
  - -iswj = isWJets
  - -mt = metType
 

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -184,7 +184,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
         std::cout << "Identified channel et and using kappa = 4" << std::endl;
         svfitAlgorithm.addLogM_fixed(true, 4);
       } 
-      else if ( std::string(key->GetName()).find("mt") != std::string::npos ) {
+      else if ( std::string(key->GetName()).find("mutau") != std::string::npos ) {
 
         std::cout << "muTauEvent" << std::endl;
         decayType1 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -735,6 +735,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("metcov10",&pfCovMatrix10);
       t->SetBranchAddress("metcov11",&pfCovMatrix11);
       // Met Unc
+      /*
       if ( channel ==  "tt" ) {
         t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnUp",&uncMetPtUp);
         t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnDown",&uncMetPtDown);
@@ -755,6 +756,17 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
         t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
         t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
       }
+      */
+      t->SetBranchAddress("met_UESUp", &uncMetPtUp);
+      t->SetBranchAddress("met_UESDown", &uncMetPtDown);
+      t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);
+      t->SetBranchAddress("metphi_UESDown", &uncMetPhiDown);
+      
+      t->SetBranchAddress("met_JESUp", &clusteredMetPtUp);
+      t->SetBranchAddress("met_JESDown", &clusteredMetPtDown);
+      t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
+      t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
+      
       
       printf("Found tree -> weighting\n");
     

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -235,83 +235,83 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       
       // If doing ES shifts, we need extra ouput branches
       //
-      float svFitMass_UP = -10;
-      float svFitPt_UP = -10;
-      float svFitEta_UP = -10;
-      float svFitPhi_UP = -10;
-      float svFitMET_UP = -10;
-      float svFitTransverseMass_UP = -10;
-      float svFitMass_DOWN = -10;
-      float svFitPt_DOWN = -10;
-      float svFitEta_DOWN = -10;
-      float svFitPhi_DOWN = -10;
-      float svFitMET_DOWN = -10;
-      float svFitTransverseMass_DOWN = -10;
+      float svFitMass_Up = -10;
+      float svFitPt_Up = -10;
+      float svFitEta_Up = -10;
+      float svFitPhi_Up = -10;
+      float svFitMET_Up = -10;
+      float svFitTransverseMass_Up = -10;
+      float svFitMass_Down = -10;
+      float svFitPt_Down = -10;
+      float svFitEta_Down = -10;
+      float svFitPhi_Down = -10;
+      float svFitMET_Down = -10;
+      float svFitTransverseMass_Down = -10;
       
-      float svFitMass_DM0_UP = -10;
-      float svFitPt_DM0_UP = -10;
-      float svFitEta_DM0_UP = -10;
-      float svFitPhi_DM0_UP = -10;
-      float svFitMET_DM0_UP = -10;
-      float svFitTransverseMass_DM0_UP = -10;
-      float svFitMass_DM0_DOWN = -10;
-      float svFitPt_DM0_DOWN = -10;
-      float svFitEta_DM0_DOWN = -10;
-      float svFitPhi_DM0_DOWN = -10;
-      float svFitMET_DM0_DOWN = -10;
-      float svFitTransverseMass_DM0_DOWN = -10;
+      float svFitMass_DM0_Up = -10;
+      float svFitPt_DM0_Up = -10;
+      float svFitEta_DM0_Up = -10;
+      float svFitPhi_DM0_Up = -10;
+      float svFitMET_DM0_Up = -10;
+      float svFitTransverseMass_DM0_Up = -10;
+      float svFitMass_DM0_Down = -10;
+      float svFitPt_DM0_Down = -10;
+      float svFitEta_DM0_Down = -10;
+      float svFitPhi_DM0_Down = -10;
+      float svFitMET_DM0_Down = -10;
+      float svFitTransverseMass_DM0_Down = -10;
       
-      float svFitMass_DM1_UP = -10;
-      float svFitPt_DM1_UP = -10;
-      float svFitEta_DM1_UP = -10;
-      float svFitPhi_DM1_UP = -10;
-      float svFitMET_DM1_UP = -10;
-      float svFitTransverseMass_DM1_UP = -10;
-      float svFitMass_DM1_DOWN = -10;
-      float svFitPt_DM1_DOWN = -10;
-      float svFitEta_DM1_DOWN = -10;
-      float svFitPhi_DM1_DOWN = -10;
-      float svFitMET_DM1_DOWN = -10;
-      float svFitTransverseMass_DM1_DOWN = -10;
+      float svFitMass_DM1_Up = -10;
+      float svFitPt_DM1_Up = -10;
+      float svFitEta_DM1_Up = -10;
+      float svFitPhi_DM1_Up = -10;
+      float svFitMET_DM1_Up = -10;
+      float svFitTransverseMass_DM1_Up = -10;
+      float svFitMass_DM1_Down = -10;
+      float svFitPt_DM1_Down = -10;
+      float svFitEta_DM1_Down = -10;
+      float svFitPhi_DM1_Down = -10;
+      float svFitMET_DM1_Down = -10;
+      float svFitTransverseMass_DM1_Down = -10;
 
-      float svFitMass_DM10_UP = -10;
-      float svFitPt_DM10_UP = -10;
-      float svFitEta_DM10_UP = -10;
-      float svFitPhi_DM10_UP = -10;
-      float svFitMET_DM10_UP = -10;
-      float svFitTransverseMass_DM10_UP = -10;
-      float svFitMass_DM10_DOWN = -10;
-      float svFitPt_DM10_DOWN = -10;
-      float svFitEta_DM10_DOWN = -10;
-      float svFitPhi_DM10_DOWN = -10;
-      float svFitMET_DM10_DOWN = -10;
-      float svFitTransverseMass_DM10_DOWN = -10;
+      float svFitMass_DM10_Up = -10;
+      float svFitPt_DM10_Up = -10;
+      float svFitEta_DM10_Up = -10;
+      float svFitPhi_DM10_Up = -10;
+      float svFitMET_DM10_Up = -10;
+      float svFitTransverseMass_DM10_Up = -10;
+      float svFitMass_DM10_Down = -10;
+      float svFitPt_DM10_Down = -10;
+      float svFitEta_DM10_Down = -10;
+      float svFitPhi_DM10_Down = -10;
+      float svFitMET_DM10_Down = -10;
+      float svFitTransverseMass_DM10_Down = -10;
 
-      float svFitMass_UncMet_UP = -10;
-      float svFitPt_UncMet_UP = -10;
-      float svFitEta_UncMet_UP = -10;
-      float svFitPhi_UncMet_UP = -10;
-      float svFitMET_UncMet_UP = -10;
-      float svFitTransverseMass_UncMet_UP = -10;
-      float svFitMass_UncMet_DOWN = -10;
-      float svFitPt_UncMet_DOWN = -10;
-      float svFitEta_UncMet_DOWN = -10;
-      float svFitPhi_UncMet_DOWN = -10;
-      float svFitMET_UncMet_DOWN = -10;
-      float svFitTransverseMass_UncMet_DOWN = -10;
+      float svFitMass_UncMet_Up = -10;
+      float svFitPt_UncMet_Up = -10;
+      float svFitEta_UncMet_Up = -10;
+      float svFitPhi_UncMet_Up = -10;
+      float svFitMET_UncMet_Up = -10;
+      float svFitTransverseMass_UncMet_Up = -10;
+      float svFitMass_UncMet_Down = -10;
+      float svFitPt_UncMet_Down = -10;
+      float svFitEta_UncMet_Down = -10;
+      float svFitPhi_UncMet_Down = -10;
+      float svFitMET_UncMet_Down = -10;
+      float svFitTransverseMass_UncMet_Down = -10;
 
-      float svFitMass_ClusteredMet_UP = -10;
-      float svFitPt_ClusteredMet_UP = -10;
-      float svFitEta_ClusteredMet_UP = -10;
-      float svFitPhi_ClusteredMet_UP = -10;
-      float svFitMET_ClusteredMet_UP = -10;
-      float svFitTransverseMass_ClusteredMet_UP = -10;
-      float svFitMass_ClusteredMet_DOWN = -10;
-      float svFitPt_ClusteredMet_DOWN = -10;
-      float svFitEta_ClusteredMet_DOWN = -10;
-      float svFitPhi_ClusteredMet_DOWN = -10;
-      float svFitMET_ClusteredMet_DOWN = -10;
-      float svFitTransverseMass_ClusteredMet_DOWN = -10;
+      float svFitMass_ClusteredMet_Up = -10;
+      float svFitPt_ClusteredMet_Up = -10;
+      float svFitEta_ClusteredMet_Up = -10;
+      float svFitPhi_ClusteredMet_Up = -10;
+      float svFitMET_ClusteredMet_Up = -10;
+      float svFitTransverseMass_ClusteredMet_Up = -10;
+      float svFitMass_ClusteredMet_Down = -10;
+      float svFitPt_ClusteredMet_Down = -10;
+      float svFitEta_ClusteredMet_Down = -10;
+      float svFitPhi_ClusteredMet_Down = -10;
+      float svFitMET_ClusteredMet_Down = -10;
+      float svFitTransverseMass_ClusteredMet_Down = -10;
       
       // tau leptons                                                                                                  
       // nominal ========================
@@ -324,197 +324,197 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       float tau2_phi = -10;
       float tau2_m   = -10;
       // up (whatever it is) ============
-      float tau1_pt_UP  = -10;
-      float tau1_eta_UP = -10;
-      float tau1_phi_UP = -10;
-      float tau1_m_UP   = -10;
-      float tau2_pt_UP  = -10;
-      float tau2_eta_UP = -10;
-      float tau2_phi_UP = -10;
-      float tau2_m_UP   = -10;
+      float tau1_pt_Up  = -10;
+      float tau1_eta_Up = -10;
+      float tau1_phi_Up = -10;
+      float tau1_m_Up   = -10;
+      float tau2_pt_Up  = -10;
+      float tau2_eta_Up = -10;
+      float tau2_phi_Up = -10;
+      float tau2_m_Up   = -10;
       // down 
-      float tau1_pt_DOWN  = -10;
-      float tau1_eta_DOWN = -10;
-      float tau1_phi_DOWN = -10;
-      float tau1_m_DOWN   = -10;
-      float tau2_pt_DOWN  = -10;
-      float tau2_eta_DOWN = -10;
-      float tau2_phi_DOWN = -10;
-      float tau2_m_DOWN   = -10;
+      float tau1_pt_Down  = -10;
+      float tau1_eta_Down = -10;
+      float tau1_phi_Down = -10;
+      float tau1_m_Down   = -10;
+      float tau2_pt_Down  = -10;
+      float tau2_eta_Down = -10;
+      float tau2_phi_Down = -10;
+      float tau2_m_Down   = -10;
       // up DM0 =========================
-      float tau1_pt_DM0_UP  = -10;
-      float tau1_eta_DM0_UP = -10;
-      float tau1_phi_DM0_UP = -10;
-      float tau1_m_DM0_UP   = -10;
-      float tau2_pt_DM0_UP  = -10;
-      float tau2_eta_DM0_UP = -10;
-      float tau2_phi_DM0_UP = -10;
-      float tau2_m_DM0_UP   = -10;
+      float tau1_pt_DM0_Up  = -10;
+      float tau1_eta_DM0_Up = -10;
+      float tau1_phi_DM0_Up = -10;
+      float tau1_m_DM0_Up   = -10;
+      float tau2_pt_DM0_Up  = -10;
+      float tau2_eta_DM0_Up = -10;
+      float tau2_phi_DM0_Up = -10;
+      float tau2_m_DM0_Up   = -10;
       // down 
-      float tau1_pt_DM0_DOWN  = -10;
-      float tau1_eta_DM0_DOWN = -10;
-      float tau1_phi_DM0_DOWN = -10;
-      float tau1_m_DM0_DOWN   = -10;
-      float tau2_pt_DM0_DOWN  = -10;
-      float tau2_eta_DM0_DOWN = -10;
-      float tau2_phi_DM0_DOWN = -10;
-      float tau2_m_DM0_DOWN   = -10;
+      float tau1_pt_DM0_Down  = -10;
+      float tau1_eta_DM0_Down = -10;
+      float tau1_phi_DM0_Down = -10;
+      float tau1_m_DM0_Down   = -10;
+      float tau2_pt_DM0_Down  = -10;
+      float tau2_eta_DM0_Down = -10;
+      float tau2_phi_DM0_Down = -10;
+      float tau2_m_DM0_Down   = -10;
       // up DM1 =========================
-      float tau1_pt_DM1_UP  = -10;
-      float tau1_eta_DM1_UP = -10;
-      float tau1_phi_DM1_UP = -10;
-      float tau1_m_DM1_UP   = -10;
-      float tau2_pt_DM1_UP  = -10;
-      float tau2_eta_DM1_UP = -10;
-      float tau2_phi_DM1_UP = -10;
-      float tau2_m_DM1_UP   = -10;
+      float tau1_pt_DM1_Up  = -10;
+      float tau1_eta_DM1_Up = -10;
+      float tau1_phi_DM1_Up = -10;
+      float tau1_m_DM1_Up   = -10;
+      float tau2_pt_DM1_Up  = -10;
+      float tau2_eta_DM1_Up = -10;
+      float tau2_phi_DM1_Up = -10;
+      float tau2_m_DM1_Up   = -10;
       // down 
-      float tau1_pt_DM1_DOWN  = -10;
-      float tau1_eta_DM1_DOWN = -10;
-      float tau1_phi_DM1_DOWN = -10;
-      float tau1_m_DM1_DOWN   = -10;
-      float tau2_pt_DM1_DOWN  = -10;
-      float tau2_eta_DM1_DOWN = -10;
-      float tau2_phi_DM1_DOWN = -10;
-      float tau2_m_DM1_DOWN   = -10;
+      float tau1_pt_DM1_Down  = -10;
+      float tau1_eta_DM1_Down = -10;
+      float tau1_phi_DM1_Down = -10;
+      float tau1_m_DM1_Down   = -10;
+      float tau2_pt_DM1_Down  = -10;
+      float tau2_eta_DM1_Down = -10;
+      float tau2_phi_DM1_Down = -10;
+      float tau2_m_DM1_Down   = -10;
       // up DM10 =========================
-      float tau1_pt_DM10_UP  = -10;
-      float tau1_eta_DM10_UP = -10;
-      float tau1_phi_DM10_UP = -10;
-      float tau1_m_DM10_UP   = -10;
-      float tau2_pt_DM10_UP  = -10;
-      float tau2_eta_DM10_UP = -10;
-      float tau2_phi_DM10_UP = -10;
-      float tau2_m_DM10_UP   = -10;
+      float tau1_pt_DM10_Up  = -10;
+      float tau1_eta_DM10_Up = -10;
+      float tau1_phi_DM10_Up = -10;
+      float tau1_m_DM10_Up   = -10;
+      float tau2_pt_DM10_Up  = -10;
+      float tau2_eta_DM10_Up = -10;
+      float tau2_phi_DM10_Up = -10;
+      float tau2_m_DM10_Up   = -10;
       // down 
-      float tau1_pt_DM10_DOWN  = -10;
-      float tau1_eta_DM10_DOWN = -10;
-      float tau1_phi_DM10_DOWN = -10;
-      float tau1_m_DM10_DOWN   = -10;
-      float tau2_pt_DM10_DOWN  = -10;
-      float tau2_eta_DM10_DOWN = -10;
-      float tau2_phi_DM10_DOWN = -10;
-      float tau2_m_DM10_DOWN   = -10;
+      float tau1_pt_DM10_Down  = -10;
+      float tau1_eta_DM10_Down = -10;
+      float tau1_phi_DM10_Down = -10;
+      float tau1_m_DM10_Down   = -10;
+      float tau2_pt_DM10_Down  = -10;
+      float tau2_eta_DM10_Down = -10;
+      float tau2_phi_DM10_Down = -10;
+      float tau2_m_DM10_Down   = -10;
       // up UncMet ========================= 
-      float tau1_pt_UncMet_UP  = -10;
-      float tau1_eta_UncMet_UP = -10;
-      float tau1_phi_UncMet_UP = -10;
-      float tau1_m_UncMet_UP   = -10;
-      float tau2_pt_UncMet_UP  = -10;
-      float tau2_eta_UncMet_UP = -10;
-      float tau2_phi_UncMet_UP = -10;
-      float tau2_m_UncMet_UP   = -10;
+      float tau1_pt_UncMet_Up  = -10;
+      float tau1_eta_UncMet_Up = -10;
+      float tau1_phi_UncMet_Up = -10;
+      float tau1_m_UncMet_Up   = -10;
+      float tau2_pt_UncMet_Up  = -10;
+      float tau2_eta_UncMet_Up = -10;
+      float tau2_phi_UncMet_Up = -10;
+      float tau2_m_UncMet_Up   = -10;
       // down 
-      float tau1_pt_UncMet_DOWN  = -10;
-      float tau1_eta_UncMet_DOWN = -10;
-      float tau1_phi_UncMet_DOWN = -10;
-      float tau1_m_UncMet_DOWN   = -10;
-      float tau2_pt_UncMet_DOWN  = -10;
-      float tau2_eta_UncMet_DOWN = -10;
-      float tau2_phi_UncMet_DOWN = -10;
-      float tau2_m_UncMet_DOWN   = -10;
+      float tau1_pt_UncMet_Down  = -10;
+      float tau1_eta_UncMet_Down = -10;
+      float tau1_phi_UncMet_Down = -10;
+      float tau1_m_UncMet_Down   = -10;
+      float tau2_pt_UncMet_Down  = -10;
+      float tau2_eta_UncMet_Down = -10;
+      float tau2_phi_UncMet_Down = -10;
+      float tau2_m_UncMet_Down   = -10;
       // up ClusteredMet ========================= 
-      float tau1_pt_ClusteredMet_UP  = -10;
-      float tau1_eta_ClusteredMet_UP = -10;
-      float tau1_phi_ClusteredMet_UP = -10;
-      float tau1_m_ClusteredMet_UP   = -10;
-      float tau2_pt_ClusteredMet_UP  = -10;
-      float tau2_eta_ClusteredMet_UP = -10;
-      float tau2_phi_ClusteredMet_UP = -10;
-      float tau2_m_ClusteredMet_UP   = -10;
+      float tau1_pt_ClusteredMet_Up  = -10;
+      float tau1_eta_ClusteredMet_Up = -10;
+      float tau1_phi_ClusteredMet_Up = -10;
+      float tau1_m_ClusteredMet_Up   = -10;
+      float tau2_pt_ClusteredMet_Up  = -10;
+      float tau2_eta_ClusteredMet_Up = -10;
+      float tau2_phi_ClusteredMet_Up = -10;
+      float tau2_m_ClusteredMet_Up   = -10;
       // down 
-      float tau1_pt_ClusteredMet_DOWN  = -10;
-      float tau1_eta_ClusteredMet_DOWN = -10;
-      float tau1_phi_ClusteredMet_DOWN = -10;
-      float tau1_m_ClusteredMet_DOWN   = -10;
-      float tau2_pt_ClusteredMet_DOWN  = -10;
-      float tau2_eta_ClusteredMet_DOWN = -10;
-      float tau2_phi_ClusteredMet_DOWN = -10;
-      float tau2_m_ClusteredMet_DOWN   = -10;
+      float tau1_pt_ClusteredMet_Down  = -10;
+      float tau1_eta_ClusteredMet_Down = -10;
+      float tau1_phi_ClusteredMet_Down = -10;
+      float tau1_m_ClusteredMet_Down   = -10;
+      float tau2_pt_ClusteredMet_Down  = -10;
+      float tau2_eta_ClusteredMet_Down = -10;
+      float tau2_phi_ClusteredMet_Down = -10;
+      float tau2_m_ClusteredMet_Down   = -10;
                                                                                   
-      TBranch *newBranch11 = t->Branch("m_sv_UP", &svFitMass_UP, "m_sv_UP/F");
-      TBranch *newBranch12 = t->Branch("pt_sv_UP", &svFitPt_UP, "pt_sv_UP/F");
-      TBranch *newBranch13 = t->Branch("eta_sv_UP", &svFitEta_UP, "eta_sv_UP/F");
-      TBranch *newBranch14 = t->Branch("phi_sv_UP", &svFitPhi_UP, "phi_sv_UP/F");
-      TBranch *newBranch15 = t->Branch("met_sv_UP", &svFitMET_UP, "met_sv_UP/F");
-      TBranch *newBranch16 = t->Branch("mt_sv_UP", &svFitTransverseMass_UP, "mt_sv_UP/F");
+      TBranch *newBranch11 = t->Branch("m_sv_Up", &svFitMass_Up, "m_sv_Up/F");
+      TBranch *newBranch12 = t->Branch("pt_sv_Up", &svFitPt_Up, "pt_sv_Up/F");
+      TBranch *newBranch13 = t->Branch("eta_sv_Up", &svFitEta_Up, "eta_sv_Up/F");
+      TBranch *newBranch14 = t->Branch("phi_sv_Up", &svFitPhi_Up, "phi_sv_Up/F");
+      TBranch *newBranch15 = t->Branch("met_sv_Up", &svFitMET_Up, "met_sv_Up/F");
+      TBranch *newBranch16 = t->Branch("mt_sv_Up", &svFitTransverseMass_Up, "mt_sv_Up/F");
 
-      TBranch *newBranch17 = t->Branch("m_sv_DOWN", &svFitMass_DOWN, "m_sv_DOWN/F");
-      TBranch *newBranch18 = t->Branch("pt_sv_DOWN", &svFitPt_DOWN, "pt_sv_DOWN/F");
-      TBranch *newBranch19 = t->Branch("eta_sv_DOWN", &svFitEta_DOWN, "eta_sv_DOWN/F");
-      TBranch *newBranch20 = t->Branch("phi_sv_DOWN", &svFitPhi_DOWN, "phi_sv_DOWN/F");
-      TBranch *newBranch21 = t->Branch("met_sv_DOWN", &svFitMET_DOWN, "met_sv_DOWN/F");
-      TBranch *newBranch22 = t->Branch("mt_sv_DOWN", &svFitTransverseMass_DOWN, "mt_sv_DOWN/F");
+      TBranch *newBranch17 = t->Branch("m_sv_Down", &svFitMass_Down, "m_sv_Down/F");
+      TBranch *newBranch18 = t->Branch("pt_sv_Down", &svFitPt_Down, "pt_sv_Down/F");
+      TBranch *newBranch19 = t->Branch("eta_sv_Down", &svFitEta_Down, "eta_sv_Down/F");
+      TBranch *newBranch20 = t->Branch("phi_sv_Down", &svFitPhi_Down, "phi_sv_Down/F");
+      TBranch *newBranch21 = t->Branch("met_sv_Down", &svFitMET_Down, "met_sv_Down/F");
+      TBranch *newBranch22 = t->Branch("mt_sv_Down", &svFitTransverseMass_Down, "mt_sv_Down/F");
 
-      TBranch *newBranch23 = t->Branch("m_sv_DM0_UP", &svFitMass_DM0_UP, "m_sv_DM0_UP/F");
-      TBranch *newBranch24 = t->Branch("pt_sv_DM0_UP", &svFitPt_DM0_UP, "pt_sv_DM0_UP/F");
-      TBranch *newBranch25 = t->Branch("eta_sv_DM0_UP", &svFitEta_DM0_UP, "eta_sv_DM0_UP/F");
-      TBranch *newBranch26 = t->Branch("phi_sv_DM0_UP", &svFitPhi_DM0_UP, "phi_sv_DM0_UP/F");
-      TBranch *newBranch27 = t->Branch("met_sv_DM0_UP", &svFitMET_DM0_UP, "met_sv_DM0_UP/F");
-      TBranch *newBranch28 = t->Branch("mt_sv_DM0_UP", &svFitTransverseMass_DM0_UP, "mt_sv_DM0_UP/F");
+      TBranch *newBranch23 = t->Branch("m_sv_DM0_Up", &svFitMass_DM0_Up, "m_sv_DM0_Up/F");
+      TBranch *newBranch24 = t->Branch("pt_sv_DM0_Up", &svFitPt_DM0_Up, "pt_sv_DM0_Up/F");
+      TBranch *newBranch25 = t->Branch("eta_sv_DM0_Up", &svFitEta_DM0_Up, "eta_sv_DM0_Up/F");
+      TBranch *newBranch26 = t->Branch("phi_sv_DM0_Up", &svFitPhi_DM0_Up, "phi_sv_DM0_Up/F");
+      TBranch *newBranch27 = t->Branch("met_sv_DM0_Up", &svFitMET_DM0_Up, "met_sv_DM0_Up/F");
+      TBranch *newBranch28 = t->Branch("mt_sv_DM0_Up", &svFitTransverseMass_DM0_Up, "mt_sv_DM0_Up/F");
 
-      TBranch *newBranch29 = t->Branch("m_sv_DM0_DOWN", &svFitMass_DM0_DOWN, "m_sv_DM0_DOWN/F");
-      TBranch *newBranch30 = t->Branch("pt_sv_DM0_DOWN", &svFitPt_DM0_DOWN, "pt_sv_DM0_DOWN/F");
-      TBranch *newBranch31 = t->Branch("eta_sv_DM0_DOWN", &svFitEta_DM0_DOWN, "eta_sv_DM0_DOWN/F");
-      TBranch *newBranch32 = t->Branch("phi_sv_DM0_DOWN", &svFitPhi_DM0_DOWN, "phi_sv_DM0_DOWN/F");
-      TBranch *newBranch33 = t->Branch("met_sv_DM0_DOWN", &svFitMET_DM0_DOWN, "met_sv_DM0_DOWN/F");
-      TBranch *newBranch34 = t->Branch("mt_sv_DM0_DOWN", &svFitTransverseMass_DM0_DOWN, "mt_sv_DM0_DOWN/F");
+      TBranch *newBranch29 = t->Branch("m_sv_DM0_Down", &svFitMass_DM0_Down, "m_sv_DM0_Down/F");
+      TBranch *newBranch30 = t->Branch("pt_sv_DM0_Down", &svFitPt_DM0_Down, "pt_sv_DM0_Down/F");
+      TBranch *newBranch31 = t->Branch("eta_sv_DM0_Down", &svFitEta_DM0_Down, "eta_sv_DM0_Down/F");
+      TBranch *newBranch32 = t->Branch("phi_sv_DM0_Down", &svFitPhi_DM0_Down, "phi_sv_DM0_Down/F");
+      TBranch *newBranch33 = t->Branch("met_sv_DM0_Down", &svFitMET_DM0_Down, "met_sv_DM0_Down/F");
+      TBranch *newBranch34 = t->Branch("mt_sv_DM0_Down", &svFitTransverseMass_DM0_Down, "mt_sv_DM0_Down/F");
 
-      TBranch *newBranch35 = t->Branch("m_sv_DM1_UP", &svFitMass_DM1_UP, "m_sv_DM1_UP/F");
-      TBranch *newBranch36 = t->Branch("pt_sv_DM1_UP", &svFitPt_DM1_UP, "pt_sv_DM1_UP/F");
-      TBranch *newBranch37 = t->Branch("eta_sv_DM1_UP", &svFitEta_DM1_UP, "eta_sv_DM1_UP/F");
-      TBranch *newBranch38 = t->Branch("phi_sv_DM1_UP", &svFitPhi_DM1_UP, "phi_sv_DM1_UP/F");
-      TBranch *newBranch39 = t->Branch("met_sv_DM1_UP", &svFitMET_DM1_UP, "met_sv_DM1_UP/F");
-      TBranch *newBranch40 = t->Branch("mt_sv_DM1_UP", &svFitTransverseMass_DM1_UP, "mt_sv_DM1_UP/F");
+      TBranch *newBranch35 = t->Branch("m_sv_DM1_Up", &svFitMass_DM1_Up, "m_sv_DM1_Up/F");
+      TBranch *newBranch36 = t->Branch("pt_sv_DM1_Up", &svFitPt_DM1_Up, "pt_sv_DM1_Up/F");
+      TBranch *newBranch37 = t->Branch("eta_sv_DM1_Up", &svFitEta_DM1_Up, "eta_sv_DM1_Up/F");
+      TBranch *newBranch38 = t->Branch("phi_sv_DM1_Up", &svFitPhi_DM1_Up, "phi_sv_DM1_Up/F");
+      TBranch *newBranch39 = t->Branch("met_sv_DM1_Up", &svFitMET_DM1_Up, "met_sv_DM1_Up/F");
+      TBranch *newBranch40 = t->Branch("mt_sv_DM1_Up", &svFitTransverseMass_DM1_Up, "mt_sv_DM1_Up/F");
 
-      TBranch *newBranch41 = t->Branch("m_sv_DM1_DOWN", &svFitMass_DM1_DOWN, "m_sv_DM1_DOWN/F");
-      TBranch *newBranch42 = t->Branch("pt_sv_DM1_DOWN", &svFitPt_DM1_DOWN, "pt_sv_DM1_DOWN/F");
-      TBranch *newBranch43 = t->Branch("eta_sv_DM1_DOWN", &svFitEta_DM1_DOWN, "eta_sv_DM1_DOWN/F");
-      TBranch *newBranch44 = t->Branch("phi_sv_DM1_DOWN", &svFitPhi_DM1_DOWN, "phi_sv_DM1_DOWN/F");
-      TBranch *newBranch45 = t->Branch("met_sv_DM1_DOWN", &svFitMET_DM1_DOWN, "met_sv_DM1_DOWN/F");
-      TBranch *newBranch46 = t->Branch("mt_sv_DM1_DOWN", &svFitTransverseMass_DM1_DOWN, "mt_sv_DM1_DOWN/F");
+      TBranch *newBranch41 = t->Branch("m_sv_DM1_Down", &svFitMass_DM1_Down, "m_sv_DM1_Down/F");
+      TBranch *newBranch42 = t->Branch("pt_sv_DM1_Down", &svFitPt_DM1_Down, "pt_sv_DM1_Down/F");
+      TBranch *newBranch43 = t->Branch("eta_sv_DM1_Down", &svFitEta_DM1_Down, "eta_sv_DM1_Down/F");
+      TBranch *newBranch44 = t->Branch("phi_sv_DM1_Down", &svFitPhi_DM1_Down, "phi_sv_DM1_Down/F");
+      TBranch *newBranch45 = t->Branch("met_sv_DM1_Down", &svFitMET_DM1_Down, "met_sv_DM1_Down/F");
+      TBranch *newBranch46 = t->Branch("mt_sv_DM1_Down", &svFitTransverseMass_DM1_Down, "mt_sv_DM1_Down/F");
 
-      TBranch *newBranch47 = t->Branch("m_sv_DM10_UP", &svFitMass_DM10_UP, "m_sv_DM10_UP/F");
-      TBranch *newBranch48 = t->Branch("pt_sv_DM10_UP", &svFitPt_DM10_UP, "pt_sv_DM10_UP/F");
-      TBranch *newBranch49 = t->Branch("eta_sv_DM10_UP", &svFitEta_DM10_UP, "eta_sv_DM10_UP/F");
-      TBranch *newBranch50 = t->Branch("phi_sv_DM10_UP", &svFitPhi_DM10_UP, "phi_sv_DM10_UP/F");
-      TBranch *newBranch51 = t->Branch("met_sv_DM10_UP", &svFitMET_DM10_UP, "met_sv_DM10_UP/F");
-      TBranch *newBranch52 = t->Branch("mt_sv_DM10_UP", &svFitTransverseMass_DM10_UP, "mt_sv_DM10_UP/F");
+      TBranch *newBranch47 = t->Branch("m_sv_DM10_Up", &svFitMass_DM10_Up, "m_sv_DM10_Up/F");
+      TBranch *newBranch48 = t->Branch("pt_sv_DM10_Up", &svFitPt_DM10_Up, "pt_sv_DM10_Up/F");
+      TBranch *newBranch49 = t->Branch("eta_sv_DM10_Up", &svFitEta_DM10_Up, "eta_sv_DM10_Up/F");
+      TBranch *newBranch50 = t->Branch("phi_sv_DM10_Up", &svFitPhi_DM10_Up, "phi_sv_DM10_Up/F");
+      TBranch *newBranch51 = t->Branch("met_sv_DM10_Up", &svFitMET_DM10_Up, "met_sv_DM10_Up/F");
+      TBranch *newBranch52 = t->Branch("mt_sv_DM10_Up", &svFitTransverseMass_DM10_Up, "mt_sv_DM10_Up/F");
 
-      TBranch *newBranch53 = t->Branch("m_sv_DM10_DOWN", &svFitMass_DM10_DOWN, "m_sv_DM10_DOWN/F");
-      TBranch *newBranch54 = t->Branch("pt_sv_DM10_DOWN", &svFitPt_DM10_DOWN, "pt_sv_DM10_DOWN/F");
-      TBranch *newBranch55 = t->Branch("eta_sv_DM10_DOWN", &svFitEta_DM10_DOWN, "eta_sv_DM10_DOWN/F");
-      TBranch *newBranch56 = t->Branch("phi_sv_DM10_DOWN", &svFitPhi_DM10_DOWN, "phi_sv_DM10_DOWN/F");
-      TBranch *newBranch57 = t->Branch("met_sv_DM10_DOWN", &svFitMET_DM10_DOWN, "met_sv_DM10_DOWN/F");
-      TBranch *newBranch58 = t->Branch("mt_sv_DM10_DOWN", &svFitTransverseMass_DM10_DOWN, "mt_sv_DM10_DOWN/F");
+      TBranch *newBranch53 = t->Branch("m_sv_DM10_Down", &svFitMass_DM10_Down, "m_sv_DM10_Down/F");
+      TBranch *newBranch54 = t->Branch("pt_sv_DM10_Down", &svFitPt_DM10_Down, "pt_sv_DM10_Down/F");
+      TBranch *newBranch55 = t->Branch("eta_sv_DM10_Down", &svFitEta_DM10_Down, "eta_sv_DM10_Down/F");
+      TBranch *newBranch56 = t->Branch("phi_sv_DM10_Down", &svFitPhi_DM10_Down, "phi_sv_DM10_Down/F");
+      TBranch *newBranch57 = t->Branch("met_sv_DM10_Down", &svFitMET_DM10_Down, "met_sv_DM10_Down/F");
+      TBranch *newBranch58 = t->Branch("mt_sv_DM10_Down", &svFitTransverseMass_DM10_Down, "mt_sv_DM10_Down/F");
 
-      TBranch *newBranch59 = t->Branch("m_sv_UncMet_UP", &svFitMass_UncMet_UP, "m_sv_UncMet_UP/F");
-      TBranch *newBranch60 = t->Branch("pt_sv_UncMet_UP", &svFitPt_UncMet_UP, "pt_sv_UncMet_UP/F");
-      TBranch *newBranch61 = t->Branch("eta_sv_UncMet_UP", &svFitEta_UncMet_UP, "eta_sv_UncMet_UP/F");
-      TBranch *newBranch62 = t->Branch("phi_sv_UncMet_UP", &svFitPhi_UncMet_UP, "phi_sv_UncMet_UP/F");
-      TBranch *newBranch63 = t->Branch("met_sv_UncMet_UP", &svFitMET_UncMet_UP, "met_sv_UncMet_UP/F");
-      TBranch *newBranch64 = t->Branch("mt_sv_UncMet_UP", &svFitTransverseMass_UncMet_UP, "mt_sv_UncMet_UP/F");
+      TBranch *newBranch59 = t->Branch("m_sv_UncMet_Up", &svFitMass_UncMet_Up, "m_sv_UncMet_Up/F");
+      TBranch *newBranch60 = t->Branch("pt_sv_UncMet_Up", &svFitPt_UncMet_Up, "pt_sv_UncMet_Up/F");
+      TBranch *newBranch61 = t->Branch("eta_sv_UncMet_Up", &svFitEta_UncMet_Up, "eta_sv_UncMet_Up/F");
+      TBranch *newBranch62 = t->Branch("phi_sv_UncMet_Up", &svFitPhi_UncMet_Up, "phi_sv_UncMet_Up/F");
+      TBranch *newBranch63 = t->Branch("met_sv_UncMet_Up", &svFitMET_UncMet_Up, "met_sv_UncMet_Up/F");
+      TBranch *newBranch64 = t->Branch("mt_sv_UncMet_Up", &svFitTransverseMass_UncMet_Up, "mt_sv_UncMet_Up/F");
 
-      TBranch *newBranch65 = t->Branch("m_sv_UncMet_DOWN", &svFitMass_UncMet_DOWN, "m_sv_UncMet_DOWN/F");
-      TBranch *newBranch66 = t->Branch("pt_sv_UncMet_DOWN", &svFitPt_UncMet_DOWN, "pt_sv_UncMet_DOWN/F");
-      TBranch *newBranch67 = t->Branch("eta_sv_UncMet_DOWN", &svFitEta_UncMet_DOWN, "eta_sv_UncMet_DOWN/F");
-      TBranch *newBranch68 = t->Branch("phi_sv_UncMet_DOWN", &svFitPhi_UncMet_DOWN, "phi_sv_UncMet_DOWN/F");
-      TBranch *newBranch69 = t->Branch("met_sv_UncMet_DOWN", &svFitMET_UncMet_DOWN, "met_sv_UncMet_DOWN/F");
-      TBranch *newBranch70 = t->Branch("mt_sv_UncMet_DOWN", &svFitTransverseMass_UncMet_DOWN, "mt_sv_UncMet_DOWN/F");
+      TBranch *newBranch65 = t->Branch("m_sv_UncMet_Down", &svFitMass_UncMet_Down, "m_sv_UncMet_Down/F");
+      TBranch *newBranch66 = t->Branch("pt_sv_UncMet_Down", &svFitPt_UncMet_Down, "pt_sv_UncMet_Down/F");
+      TBranch *newBranch67 = t->Branch("eta_sv_UncMet_Down", &svFitEta_UncMet_Down, "eta_sv_UncMet_Down/F");
+      TBranch *newBranch68 = t->Branch("phi_sv_UncMet_Down", &svFitPhi_UncMet_Down, "phi_sv_UncMet_Down/F");
+      TBranch *newBranch69 = t->Branch("met_sv_UncMet_Down", &svFitMET_UncMet_Down, "met_sv_UncMet_Down/F");
+      TBranch *newBranch70 = t->Branch("mt_sv_UncMet_Down", &svFitTransverseMass_UncMet_Down, "mt_sv_UncMet_Down/F");
 
-      TBranch *newBranch71 = t->Branch("m_sv_ClusteredMet_UP", &svFitMass_ClusteredMet_UP, "m_sv_ClusteredMet_UP/F");
-      TBranch *newBranch72 = t->Branch("pt_sv_ClusteredMet_UP", &svFitPt_ClusteredMet_UP, "pt_sv_ClusteredMet_UP/F");
-      TBranch *newBranch73 = t->Branch("eta_sv_ClusteredMet_UP", &svFitEta_ClusteredMet_UP, "eta_sv_ClusteredMet_UP/F");
-      TBranch *newBranch74 = t->Branch("phi_sv_ClusteredMet_UP", &svFitPhi_ClusteredMet_UP, "phi_sv_ClusteredMet_UP/F");
-      TBranch *newBranch75 = t->Branch("met_sv_ClusteredMet_UP", &svFitMET_ClusteredMet_UP, "met_sv_ClusteredMet_UP/F");
-      TBranch *newBranch76 = t->Branch("mt_sv_ClusteredMet_UP", &svFitTransverseMass_ClusteredMet_UP, "mt_sv_ClusteredMet_UP/F");
+      TBranch *newBranch71 = t->Branch("m_sv_ClusteredMet_Up", &svFitMass_ClusteredMet_Up, "m_sv_ClusteredMet_Up/F");
+      TBranch *newBranch72 = t->Branch("pt_sv_ClusteredMet_Up", &svFitPt_ClusteredMet_Up, "pt_sv_ClusteredMet_Up/F");
+      TBranch *newBranch73 = t->Branch("eta_sv_ClusteredMet_Up", &svFitEta_ClusteredMet_Up, "eta_sv_ClusteredMet_Up/F");
+      TBranch *newBranch74 = t->Branch("phi_sv_ClusteredMet_Up", &svFitPhi_ClusteredMet_Up, "phi_sv_ClusteredMet_Up/F");
+      TBranch *newBranch75 = t->Branch("met_sv_ClusteredMet_Up", &svFitMET_ClusteredMet_Up, "met_sv_ClusteredMet_Up/F");
+      TBranch *newBranch76 = t->Branch("mt_sv_ClusteredMet_Up", &svFitTransverseMass_ClusteredMet_Up, "mt_sv_ClusteredMet_Up/F");
 
-      TBranch *newBranch77 = t->Branch("m_sv_ClusteredMet_DOWN", &svFitMass_ClusteredMet_DOWN, "m_sv_ClusteredMet_DOWN/F");
-      TBranch *newBranch78 = t->Branch("pt_sv_ClusteredMet_DOWN", &svFitPt_ClusteredMet_DOWN, "pt_sv_ClusteredMet_DOWN/F");
-      TBranch *newBranch79 = t->Branch("eta_sv_ClusteredMet_DOWN", &svFitEta_ClusteredMet_DOWN, "eta_sv_ClusteredMet_DOWN/F");
-      TBranch *newBranch80 = t->Branch("phi_sv_ClusteredMet_DOWN", &svFitPhi_ClusteredMet_DOWN, "phi_sv_ClusteredMet_DOWN/F");
-      TBranch *newBranch81 = t->Branch("met_sv_ClusteredMet_DOWN", &svFitMET_ClusteredMet_DOWN, "met_sv_ClusteredMet_DOWN/F");
-      TBranch *newBranch82 = t->Branch("mt_sv_ClusteredMet_DOWN", &svFitTransverseMass_ClusteredMet_DOWN, "mt_sv_ClusteredMet_DOWN/F");
+      TBranch *newBranch77 = t->Branch("m_sv_ClusteredMet_Down", &svFitMass_ClusteredMet_Down, "m_sv_ClusteredMet_Down/F");
+      TBranch *newBranch78 = t->Branch("pt_sv_ClusteredMet_Down", &svFitPt_ClusteredMet_Down, "pt_sv_ClusteredMet_Down/F");
+      TBranch *newBranch79 = t->Branch("eta_sv_ClusteredMet_Down", &svFitEta_ClusteredMet_Down, "eta_sv_ClusteredMet_Down/F");
+      TBranch *newBranch80 = t->Branch("phi_sv_ClusteredMet_Down", &svFitPhi_ClusteredMet_Down, "phi_sv_ClusteredMet_Down/F");
+      TBranch *newBranch81 = t->Branch("met_sv_ClusteredMet_Down", &svFitMET_ClusteredMet_Down, "met_sv_ClusteredMet_Down/F");
+      TBranch *newBranch82 = t->Branch("mt_sv_ClusteredMet_Down", &svFitTransverseMass_ClusteredMet_Down, "mt_sv_ClusteredMet_Down/F");
     
       TBranch *newBranch83 = t->Branch("metcorClusteredDown",    &metcorClusteredDown,   "metcorClusteredDown/F");
       TBranch *newBranch84 = t->Branch("metcorphiClusteredDown", &metcorphiClusteredDown,"metcorphiClusteredDown/F");
@@ -536,114 +536,114 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       tau4VectorBranches.push_back(t->Branch("tau2_phi", &tau2_phi, "tau2_phi/F"));
       tau4VectorBranches.push_back(t->Branch("tau2_m",   &tau2_m,   "tau2_m/F"));
       // up
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_UP",  &tau1_pt_UP,  "tau1_pt_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_UP", &tau1_eta_UP, "tau1_eta_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_UP", &tau1_phi_UP, "tau1_phi_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_UP",   &tau1_m_UP,   "tau1_m_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_UP",  &tau2_pt_UP,  "tau2_pt_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_UP", &tau2_eta_UP, "tau2_eta_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_UP", &tau2_phi_UP, "tau2_phi_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_UP",   &tau2_m_UP,   "tau2_m_UP/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_Up",  &tau1_pt_Up,  "tau1_pt_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_Up", &tau1_eta_Up, "tau1_eta_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_Up", &tau1_phi_Up, "tau1_phi_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_Up",   &tau1_m_Up,   "tau1_m_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_Up",  &tau2_pt_Up,  "tau2_pt_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_Up", &tau2_eta_Up, "tau2_eta_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_Up", &tau2_phi_Up, "tau2_phi_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_Up",   &tau2_m_Up,   "tau2_m_Up/F"));
       // down
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DOWN",  &tau1_pt_DOWN,  "tau1_pt_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DOWN", &tau1_eta_DOWN, "tau1_eta_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DOWN", &tau1_phi_DOWN, "tau1_phi_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DOWN",   &tau1_m_DOWN,   "tau1_m_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DOWN",  &tau2_pt_DOWN,  "tau2_pt_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DOWN", &tau2_eta_DOWN, "tau2_eta_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DOWN", &tau2_phi_DOWN, "tau2_phi_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DOWN",   &tau2_m_DOWN,   "tau2_m_DOWN/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_Down",  &tau1_pt_Down,  "tau1_pt_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_Down", &tau1_eta_Down, "tau1_eta_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_Down", &tau1_phi_Down, "tau1_phi_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_Down",   &tau1_m_Down,   "tau1_m_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_Down",  &tau2_pt_Down,  "tau2_pt_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_Down", &tau2_eta_Down, "tau2_eta_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_Down", &tau2_phi_Down, "tau2_phi_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_Down",   &tau2_m_Down,   "tau2_m_Down/F"));
       // up DM0
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM0_UP",  &tau1_pt_DM0_UP,  "tau1_pt_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM0_UP", &tau1_eta_DM0_UP, "tau1_eta_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM0_UP", &tau1_phi_DM0_UP, "tau1_phi_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DM0_UP",   &tau1_m_DM0_UP,   "tau1_m_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM0_UP",  &tau2_pt_DM0_UP,  "tau2_pt_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM0_UP", &tau2_eta_DM0_UP, "tau2_eta_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM0_UP", &tau2_phi_DM0_UP, "tau2_phi_DM0_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DM0_UP",   &tau2_m_DM0_UP,   "tau2_m_DM0_UP/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM0_Up",  &tau1_pt_DM0_Up,  "tau1_pt_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM0_Up", &tau1_eta_DM0_Up, "tau1_eta_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM0_Up", &tau1_phi_DM0_Up, "tau1_phi_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_DM0_Up",   &tau1_m_DM0_Up,   "tau1_m_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM0_Up",  &tau2_pt_DM0_Up,  "tau2_pt_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM0_Up", &tau2_eta_DM0_Up, "tau2_eta_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM0_Up", &tau2_phi_DM0_Up, "tau2_phi_DM0_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_DM0_Up",   &tau2_m_DM0_Up,   "tau2_m_DM0_Up/F"));
       // down
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM0_DOWN",  &tau1_pt_DM0_DOWN,  "tau1_pt_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM0_DOWN", &tau1_eta_DM0_DOWN, "tau1_eta_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM0_DOWN", &tau1_phi_DM0_DOWN, "tau1_phi_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DM0_DOWN",   &tau1_m_DM0_DOWN,   "tau1_m_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM0_DOWN",  &tau2_pt_DM0_DOWN,  "tau2_pt_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM0_DOWN", &tau2_eta_DM0_DOWN, "tau2_eta_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM0_DOWN", &tau2_phi_DM0_DOWN, "tau2_phi_DM0_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DM0_DOWN",   &tau2_m_DM0_DOWN,   "tau2_m_DM0_DOWN/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM0_Down",  &tau1_pt_DM0_Down,  "tau1_pt_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM0_Down", &tau1_eta_DM0_Down, "tau1_eta_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM0_Down", &tau1_phi_DM0_Down, "tau1_phi_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_DM0_Down",   &tau1_m_DM0_Down,   "tau1_m_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM0_Down",  &tau2_pt_DM0_Down,  "tau2_pt_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM0_Down", &tau2_eta_DM0_Down, "tau2_eta_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM0_Down", &tau2_phi_DM0_Down, "tau2_phi_DM0_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_DM0_Down",   &tau2_m_DM0_Down,   "tau2_m_DM0_Down/F"));
       // up DM1
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM1_UP",  &tau1_pt_DM1_UP,  "tau1_pt_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM1_UP", &tau1_eta_DM1_UP, "tau1_eta_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM1_UP", &tau1_phi_DM1_UP, "tau1_phi_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DM1_UP",   &tau1_m_DM1_UP,   "tau1_m_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM1_UP",  &tau2_pt_DM1_UP,  "tau2_pt_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM1_UP", &tau2_eta_DM1_UP, "tau2_eta_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM1_UP", &tau2_phi_DM1_UP, "tau2_phi_DM1_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DM1_UP",   &tau2_m_DM1_UP,   "tau2_m_DM1_UP/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM1_Up",  &tau1_pt_DM1_Up,  "tau1_pt_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM1_Up", &tau1_eta_DM1_Up, "tau1_eta_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM1_Up", &tau1_phi_DM1_Up, "tau1_phi_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_DM1_Up",   &tau1_m_DM1_Up,   "tau1_m_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM1_Up",  &tau2_pt_DM1_Up,  "tau2_pt_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM1_Up", &tau2_eta_DM1_Up, "tau2_eta_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM1_Up", &tau2_phi_DM1_Up, "tau2_phi_DM1_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_DM1_Up",   &tau2_m_DM1_Up,   "tau2_m_DM1_Up/F"));
       // down
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM1_DOWN",  &tau1_pt_DM1_DOWN,  "tau1_pt_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM1_DOWN", &tau1_eta_DM1_DOWN, "tau1_eta_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM1_DOWN", &tau1_phi_DM1_DOWN, "tau1_phi_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DM1_DOWN",   &tau1_m_DM1_DOWN,   "tau1_m_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM1_DOWN",  &tau2_pt_DM1_DOWN,  "tau2_pt_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM1_DOWN", &tau2_eta_DM1_DOWN, "tau2_eta_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM1_DOWN", &tau2_phi_DM1_DOWN, "tau2_phi_DM1_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DM1_DOWN",   &tau2_m_DM1_DOWN,   "tau2_m_DM1_DOWN/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM1_Down",  &tau1_pt_DM1_Down,  "tau1_pt_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM1_Down", &tau1_eta_DM1_Down, "tau1_eta_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM1_Down", &tau1_phi_DM1_Down, "tau1_phi_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_DM1_Down",   &tau1_m_DM1_Down,   "tau1_m_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM1_Down",  &tau2_pt_DM1_Down,  "tau2_pt_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM1_Down", &tau2_eta_DM1_Down, "tau2_eta_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM1_Down", &tau2_phi_DM1_Down, "tau2_phi_DM1_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_DM1_Down",   &tau2_m_DM1_Down,   "tau2_m_DM1_Down/F"));
       // up DM10
     
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM10_UP",  &tau1_pt_DM10_UP,  "tau1_pt_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM10_UP", &tau1_eta_DM10_UP, "tau1_eta_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM10_UP", &tau1_phi_DM10_UP, "tau1_phi_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DM10_UP",   &tau1_m_DM10_UP,   "tau1_m_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM10_UP",  &tau2_pt_DM10_UP,  "tau2_pt_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM10_UP", &tau2_eta_DM10_UP, "tau2_eta_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM10_UP", &tau2_phi_DM10_UP, "tau2_phi_DM10_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DM10_UP",   &tau2_m_DM10_UP,   "tau2_m_DM10_UP/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM10_Up",  &tau1_pt_DM10_Up,  "tau1_pt_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM10_Up", &tau1_eta_DM10_Up, "tau1_eta_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM10_Up", &tau1_phi_DM10_Up, "tau1_phi_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_DM10_Up",   &tau1_m_DM10_Up,   "tau1_m_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM10_Up",  &tau2_pt_DM10_Up,  "tau2_pt_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM10_Up", &tau2_eta_DM10_Up, "tau2_eta_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM10_Up", &tau2_phi_DM10_Up, "tau2_phi_DM10_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_DM10_Up",   &tau2_m_DM10_Up,   "tau2_m_DM10_Up/F"));
       // down
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM10_DOWN",  &tau1_pt_DM10_DOWN,  "tau1_pt_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM10_DOWN", &tau1_eta_DM10_DOWN, "tau1_eta_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM10_DOWN", &tau1_phi_DM10_DOWN, "tau1_phi_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_DM10_DOWN",   &tau1_m_DM10_DOWN,   "tau1_m_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM10_DOWN",  &tau2_pt_DM10_DOWN,  "tau2_pt_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM10_DOWN", &tau2_eta_DM10_DOWN, "tau2_eta_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM10_DOWN", &tau2_phi_DM10_DOWN, "tau2_phi_DM10_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_DM10_DOWN",   &tau2_m_DM10_DOWN,   "tau2_m_DM10_DOWN/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_DM10_Down",  &tau1_pt_DM10_Down,  "tau1_pt_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_DM10_Down", &tau1_eta_DM10_Down, "tau1_eta_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_DM10_Down", &tau1_phi_DM10_Down, "tau1_phi_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_DM10_Down",   &tau1_m_DM10_Down,   "tau1_m_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_DM10_Down",  &tau2_pt_DM10_Down,  "tau2_pt_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_DM10_Down", &tau2_eta_DM10_Down, "tau2_eta_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_DM10_Down", &tau2_phi_DM10_Down, "tau2_phi_DM10_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_DM10_Down",   &tau2_m_DM10_Down,   "tau2_m_DM10_Down/F"));
       // up UncMet
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_UncMet_UP",  &tau1_pt_UncMet_UP,  "tau1_pt_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_UncMet_UP", &tau1_eta_UncMet_UP, "tau1_eta_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_UncMet_UP", &tau1_phi_UncMet_UP, "tau1_phi_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_UncMet_UP",   &tau1_m_UncMet_UP,   "tau1_m_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_UncMet_UP",  &tau2_pt_UncMet_UP,  "tau2_pt_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_UncMet_UP", &tau2_eta_UncMet_UP, "tau2_eta_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_UncMet_UP", &tau2_phi_UncMet_UP, "tau2_phi_UncMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_UncMet_UP",   &tau2_m_UncMet_UP,   "tau2_m_UncMet_UP/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_UncMet_Up",  &tau1_pt_UncMet_Up,  "tau1_pt_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_UncMet_Up", &tau1_eta_UncMet_Up, "tau1_eta_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_UncMet_Up", &tau1_phi_UncMet_Up, "tau1_phi_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_UncMet_Up",   &tau1_m_UncMet_Up,   "tau1_m_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_UncMet_Up",  &tau2_pt_UncMet_Up,  "tau2_pt_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_UncMet_Up", &tau2_eta_UncMet_Up, "tau2_eta_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_UncMet_Up", &tau2_phi_UncMet_Up, "tau2_phi_UncMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_UncMet_Up",   &tau2_m_UncMet_Up,   "tau2_m_UncMet_Up/F"));
       // down
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_UncMet_DOWN",  &tau1_pt_UncMet_DOWN,  "tau1_pt_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_UncMet_DOWN", &tau1_eta_UncMet_DOWN, "tau1_eta_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_UncMet_DOWN", &tau1_phi_UncMet_DOWN, "tau1_phi_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_UncMet_DOWN",   &tau1_m_UncMet_DOWN,   "tau1_m_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_UncMet_DOWN",  &tau2_pt_UncMet_DOWN,  "tau2_pt_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_UncMet_DOWN", &tau2_eta_UncMet_DOWN, "tau2_eta_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_UncMet_DOWN", &tau2_phi_UncMet_DOWN, "tau2_phi_UncMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_UncMet_DOWN",   &tau2_m_UncMet_DOWN,   "tau2_m_UncMet_DOWN/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_UncMet_Down",  &tau1_pt_UncMet_Down,  "tau1_pt_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_UncMet_Down", &tau1_eta_UncMet_Down, "tau1_eta_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_UncMet_Down", &tau1_phi_UncMet_Down, "tau1_phi_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_UncMet_Down",   &tau1_m_UncMet_Down,   "tau1_m_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_UncMet_Down",  &tau2_pt_UncMet_Down,  "tau2_pt_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_UncMet_Down", &tau2_eta_UncMet_Down, "tau2_eta_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_UncMet_Down", &tau2_phi_UncMet_Down, "tau2_phi_UncMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_UncMet_Down",   &tau2_m_UncMet_Down,   "tau2_m_UncMet_Down/F"));
       // up ClusteredMet
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_ClusteredMet_UP",  &tau1_pt_ClusteredMet_UP,  "tau1_pt_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_ClusteredMet_UP", &tau1_eta_ClusteredMet_UP, "tau1_eta_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_ClusteredMet_UP", &tau1_phi_ClusteredMet_UP, "tau1_phi_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_ClusteredMet_UP",   &tau1_m_ClusteredMet_UP,   "tau1_m_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_ClusteredMet_UP",  &tau2_pt_ClusteredMet_UP,  "tau2_pt_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_ClusteredMet_UP", &tau2_eta_ClusteredMet_UP, "tau2_eta_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_ClusteredMet_UP", &tau2_phi_ClusteredMet_UP, "tau2_phi_ClusteredMet_UP/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_ClusteredMet_UP",   &tau2_m_ClusteredMet_UP,   "tau2_m_ClusteredMet_UP/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_ClusteredMet_Up",  &tau1_pt_ClusteredMet_Up,  "tau1_pt_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_ClusteredMet_Up", &tau1_eta_ClusteredMet_Up, "tau1_eta_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_ClusteredMet_Up", &tau1_phi_ClusteredMet_Up, "tau1_phi_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_ClusteredMet_Up",   &tau1_m_ClusteredMet_Up,   "tau1_m_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_ClusteredMet_Up",  &tau2_pt_ClusteredMet_Up,  "tau2_pt_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_ClusteredMet_Up", &tau2_eta_ClusteredMet_Up, "tau2_eta_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_ClusteredMet_Up", &tau2_phi_ClusteredMet_Up, "tau2_phi_ClusteredMet_Up/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_ClusteredMet_Up",   &tau2_m_ClusteredMet_Up,   "tau2_m_ClusteredMet_Up/F"));
       // down
-      tau4VectorBranches.push_back(t->Branch("tau1_pt_ClusteredMet_DOWN",  &tau1_pt_ClusteredMet_DOWN,  "tau1_pt_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_eta_ClusteredMet_DOWN", &tau1_eta_ClusteredMet_DOWN, "tau1_eta_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_phi_ClusteredMet_DOWN", &tau1_phi_ClusteredMet_DOWN, "tau1_phi_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau1_m_ClusteredMet_DOWN",   &tau1_m_ClusteredMet_DOWN,   "tau1_m_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_pt_ClusteredMet_DOWN",  &tau2_pt_ClusteredMet_DOWN,  "tau2_pt_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_eta_ClusteredMet_DOWN", &tau2_eta_ClusteredMet_DOWN, "tau2_eta_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_phi_ClusteredMet_DOWN", &tau2_phi_ClusteredMet_DOWN, "tau2_phi_ClusteredMet_DOWN/F"));
-      tau4VectorBranches.push_back(t->Branch("tau2_m_ClusteredMet_DOWN",   &tau2_m_ClusteredMet_DOWN,   "tau2_m_ClusteredMet_DOWN/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_pt_ClusteredMet_Down",  &tau1_pt_ClusteredMet_Down,  "tau1_pt_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_eta_ClusteredMet_Down", &tau1_eta_ClusteredMet_Down, "tau1_eta_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_phi_ClusteredMet_Down", &tau1_phi_ClusteredMet_Down, "tau1_phi_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau1_m_ClusteredMet_Down",   &tau1_m_ClusteredMet_Down,   "tau1_m_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_pt_ClusteredMet_Down",  &tau2_pt_ClusteredMet_Down,  "tau2_pt_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_eta_ClusteredMet_Down", &tau2_eta_ClusteredMet_Down, "tau2_eta_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_phi_ClusteredMet_Down", &tau2_phi_ClusteredMet_Down, "tau2_phi_ClusteredMet_Down/F"));
+      tau4VectorBranches.push_back(t->Branch("tau2_m_ClusteredMet_Down",   &tau2_m_ClusteredMet_Down,   "tau2_m_ClusteredMet_Down/F"));
       std::cout << "That's a lot of tau 4-vector branches! N = " << tau4VectorBranches.size() << std::endl;
     
       unsigned long long evt;
@@ -833,20 +833,20 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 
           // MET systematics
           std::cout << "MET Unclustered Energy Up   ---  ";
-          runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_UP, svFitPt_UncMet_UP, svFitEta_UncMet_UP, 
-              svFitPhi_UncMet_UP, svFitMET_UncMet_UP, svFitTransverseMass_UncMet_UP, tau1_UncMet_up, tau2_UncMet_up);
+          runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_Up, svFitPt_UncMet_Up, svFitEta_UncMet_Up, 
+              svFitPhi_UncMet_Up, svFitMET_UncMet_Up, svFitTransverseMass_UncMet_Up, tau1_UncMet_up, tau2_UncMet_up);
 
           std::cout << "MET Unclustered Energy Down ---  ";
-          runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_DOWN, svFitPt_UncMet_DOWN, svFitEta_UncMet_DOWN, 
-              svFitPhi_UncMet_DOWN, svFitMET_UncMet_DOWN, svFitTransverseMass_UncMet_DOWN, tau1_UncMet_down, tau2_UncMet_down);
+          runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_Down, svFitPt_UncMet_Down, svFitEta_UncMet_Down, 
+              svFitPhi_UncMet_Down, svFitMET_UncMet_Down, svFitTransverseMass_UncMet_Down, tau1_UncMet_down, tau2_UncMet_down);
 
           std::cout << "MET Clustered Energy Up     ---  ";
-          runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_UP, svFitPt_ClusteredMet_UP, 
-              svFitEta_ClusteredMet_UP, svFitPhi_ClusteredMet_UP, svFitMET_ClusteredMet_UP, svFitTransverseMass_ClusteredMet_UP, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
+          runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_Up, svFitPt_ClusteredMet_Up, 
+              svFitEta_ClusteredMet_Up, svFitPhi_ClusteredMet_Up, svFitMET_ClusteredMet_Up, svFitTransverseMass_ClusteredMet_Up, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
 
           std::cout << "MET Clustered Energy Down   ---  ";
-          runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_DOWN, svFitPt_ClusteredMet_DOWN, 
-              svFitEta_ClusteredMet_DOWN, svFitPhi_ClusteredMet_DOWN, svFitMET_ClusteredMet_DOWN, svFitTransverseMass_ClusteredMet_DOWN, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
+          runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_Down, svFitPt_ClusteredMet_Down, 
+              svFitEta_ClusteredMet_Down, svFitPhi_ClusteredMet_Down, svFitMET_ClusteredMet_Down, svFitTransverseMass_ClusteredMet_Down, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
 
           std::cout<< "Shifted MET Summary:\n\tmetcorr_ex " << metcorr_ex << " --- metcorrUncUp_ex " << metcorrUncUp_ex << " metcorrUncDown_ex " << metcorrUncDown_ex
               << " metcorrClusteredUp_ex " << metcorrClusteredUp_ex << " metcorrClusteredDown_ex " << metcorrClusteredDown_ex << std::endl;
@@ -868,35 +868,35 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
           if(doES) {
             
             // corrections only need to be done once
-            float ES_UP( 1. ), ES_DOWN( 1. ); // shift TES
+            float ES_Up( 1. ), ES_Down( 1. ); // shift TES
             if (gen_match_2 == 5) { // 0.6% uncertainty on hadronic tau
-              ES_UP = 1.012;
-              ES_DOWN = 0.988;
+              ES_Up = 1.012;
+              ES_Down = 0.988;
             } else if (gen_match_2 < 5) { // 1.0% uncertainty on gen matched ele/mu
-              ES_UP = 1.01;
-              ES_DOWN = 0.99;
+              ES_Up = 1.01;
+              ES_Down = 0.99;
             }
             
-            double pt_UP  ( pt2 * ES_UP ), pt_DOWN( pt2 * ES_DOWN ); // shift tau pT by energy scale
-            double dx_UP  ( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP ) - 1.) ),
-                   dy_UP  ( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP ) - 1.) ),
-                   dx_DOWN( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN ) - 1.) ),
-                   dy_DOWN( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN ) - 1.) ); 
-            double metcorr_ex_UP  ( metcorr_ex + dx_UP ), 
-                   metcorr_ey_UP  ( metcorr_ey + dy_UP ),
-                   metcorr_ex_DOWN( metcorr_ex + dx_DOWN ),
-                   metcorr_ey_DOWN( metcorr_ey + dy_DOWN );
+            double pt_Up  ( pt2 * ES_Up ), pt_Down( pt2 * ES_Down ); // shift tau pT by energy scale
+            double dx_Up  ( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Up ) - 1.) ),
+                   dy_Up  ( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Up ) - 1.) ),
+                   dx_Down( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Down ) - 1.) ),
+                   dy_Down( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Down ) - 1.) ); 
+            double metcorr_ex_Up  ( metcorr_ex + dx_Up ), 
+                   metcorr_ey_Up  ( metcorr_ey + dy_Up ),
+                   metcorr_ex_Down( metcorr_ex + dx_Down ),
+                   metcorr_ey_Down( metcorr_ey + dy_Down );
 
             // leptons shifted up
             std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
                 classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
+                classic_svFit::MeasuredTauLepton(decayType2,  pt_Up, eta2, phi2,  mass2, decayMode2)
             };
 
             // leptons shifted down
             std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
                 classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
+                classic_svFit::MeasuredTauLepton(decayType2,  pt_Down, eta2, phi2,  mass2, decayMode2)
             };
           
             /////////////////////////////
@@ -906,15 +906,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // all tau shift up
             if (gen_match_2 < 6) {
               std::cout << "Tau shift up" << std::endl;
-              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, 
-                    svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_Up, svFitPt_Up, 
+                    svFitEta_Up, svFitPhi_Up, svFitMET_Up, svFitTransverseMass_Up, tau1_up, tau2_up);
             } else {
-              svFitMass_UP=svFitMass;
-              svFitPt_UP=svFitPt;
-              svFitEta_UP=svFitEta;
-              svFitPhi_UP=svFitPhi;
-              svFitMET_UP=svFitMET;
-              svFitTransverseMass_UP=svFitTransverseMass;
+              svFitMass_Up=svFitMass;
+              svFitPt_Up=svFitPt;
+              svFitEta_Up=svFitEta;
+              svFitPhi_Up=svFitPhi;
+              svFitMET_Up=svFitMET;
+              svFitTransverseMass_Up=svFitTransverseMass;
               tau1_up = tau1;
               tau2_up = tau2;
             }
@@ -922,16 +922,16 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM0 shifted up
             if (gen_match_2 == 5 && decayMode2 == 0) {
               std::cout << "DM0 shift up" << std::endl;
-              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM0_UP, svFitPt_DM0_UP, 
-                    svFitEta_DM0_UP, svFitPhi_DM0_UP, svFitMET_DM0_UP, svFitTransverseMass_DM0_UP, tau1_DM0_up, tau2_DM0_up);
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_DM0_Up, svFitPt_DM0_Up, 
+                    svFitEta_DM0_Up, svFitPhi_DM0_Up, svFitMET_DM0_Up, svFitTransverseMass_DM0_Up, tau1_DM0_up, tau2_DM0_up);
 
             } else {
-              svFitMass_DM0_UP=svFitMass;
-              svFitPt_DM0_UP=svFitPt;
-              svFitEta_DM0_UP=svFitEta;
-              svFitPhi_DM0_UP=svFitPhi;
-              svFitMET_DM0_UP=svFitMET;
-              svFitTransverseMass_DM0_UP=svFitTransverseMass;
+              svFitMass_DM0_Up=svFitMass;
+              svFitPt_DM0_Up=svFitPt;
+              svFitEta_DM0_Up=svFitEta;
+              svFitPhi_DM0_Up=svFitPhi;
+              svFitMET_DM0_Up=svFitMET;
+              svFitTransverseMass_DM0_Up=svFitTransverseMass;
               tau1_DM0_up = tau1;
               tau2_DM0_up = tau2;
             }
@@ -939,15 +939,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM1 shifted up
             if (gen_match_2 == 5 && decayMode2 == 1) {
               std::cout << "DM1 shift up" << std::endl;
-              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, 
-                    svFitEta_DM1_UP, svFitPhi_DM1_UP, svFitMET_DM1_UP, svFitTransverseMass_DM1_UP, tau1_DM1_up, tau2_DM1_up);
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_DM1_Up, svFitPt_DM1_Up, 
+                    svFitEta_DM1_Up, svFitPhi_DM1_Up, svFitMET_DM1_Up, svFitTransverseMass_DM1_Up, tau1_DM1_up, tau2_DM1_up);
             } else {
-              svFitMass_DM1_UP=svFitMass;
-              svFitPt_DM1_UP=svFitPt;
-              svFitEta_DM1_UP=svFitEta;
-              svFitPhi_DM1_UP=svFitPhi;
-              svFitMET_DM1_UP=svFitMET;
-              svFitTransverseMass_DM1_UP=svFitTransverseMass;
+              svFitMass_DM1_Up=svFitMass;
+              svFitPt_DM1_Up=svFitPt;
+              svFitEta_DM1_Up=svFitEta;
+              svFitPhi_DM1_Up=svFitPhi;
+              svFitMET_DM1_Up=svFitMET;
+              svFitTransverseMass_DM1_Up=svFitTransverseMass;
               tau1_DM1_up = tau1;
               tau2_DM1_up = tau2;
             }
@@ -955,15 +955,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM10 shifted up
             if (gen_match_2 == 5 && decayMode2 == 10) {
               std::cout << "DM10 shift up" << std::endl;
-              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, 
-                    svFitEta_DM10_UP, svFitPhi_DM10_UP, svFitMET_DM10_UP, svFitTransverseMass_DM10_UP, tau1_DM10_up, tau2_DM10_up);
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_DM10_Up, svFitPt_DM10_Up, 
+                    svFitEta_DM10_Up, svFitPhi_DM10_Up, svFitMET_DM10_Up, svFitTransverseMass_DM10_Up, tau1_DM10_up, tau2_DM10_up);
             } else {
-              svFitMass_DM10_UP=svFitMass;
-              svFitPt_DM10_UP=svFitPt;
-              svFitEta_DM10_UP=svFitEta;
-              svFitPhi_DM10_UP=svFitPhi;
-              svFitMET_DM10_UP=svFitMET;
-              svFitTransverseMass_DM10_UP=svFitTransverseMass;
+              svFitMass_DM10_Up=svFitMass;
+              svFitPt_DM10_Up=svFitPt;
+              svFitEta_DM10_Up=svFitEta;
+              svFitPhi_DM10_Up=svFitPhi;
+              svFitMET_DM10_Up=svFitMET;
+              svFitTransverseMass_DM10_Up=svFitTransverseMass;
               tau1_DM10_up = tau1;
               tau2_DM10_up = tau2;
             }
@@ -975,15 +975,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // all tau shift down
             if (gen_match_2 < 6) {
               std::cout << "Tau shift down" << std::endl;
-              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, 
-                    svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_Down, svFitPt_Down, 
+                    svFitEta_Down, svFitPhi_Down, svFitMET_Down, svFitTransverseMass_Down, tau1_down, tau2_down);
             } else {
-              svFitMass_DOWN=svFitMass;
-              svFitPt_DOWN=svFitPt;
-              svFitEta_DOWN=svFitEta;
-              svFitPhi_DOWN=svFitPhi;
-              svFitMET_DOWN=svFitMET;
-              svFitTransverseMass_DOWN=svFitTransverseMass;
+              svFitMass_Down=svFitMass;
+              svFitPt_Down=svFitPt;
+              svFitEta_Down=svFitEta;
+              svFitPhi_Down=svFitPhi;
+              svFitMET_Down=svFitMET;
+              svFitTransverseMass_Down=svFitTransverseMass;
               tau1_down = tau1;
               tau2_down = tau2;
             }
@@ -991,15 +991,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM0 shifted down
             if (gen_match_2 == 5 && decayMode2 == 0) {
               std::cout << "DM0 shift down" << std::endl;
-              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM0_DOWN, svFitPt_DM0_DOWN, 
-                    svFitEta_DM0_DOWN, svFitPhi_DM0_DOWN, svFitMET_DM0_DOWN, svFitTransverseMass_DM0_DOWN, tau1_DM0_down, tau2_DM0_down);
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_DM0_Down, svFitPt_DM0_Down, 
+                    svFitEta_DM0_Down, svFitPhi_DM0_Down, svFitMET_DM0_Down, svFitTransverseMass_DM0_Down, tau1_DM0_down, tau2_DM0_down);
             } else {
-              svFitMass_DM0_DOWN=svFitMass;
-              svFitPt_DM0_DOWN=svFitPt;
-              svFitEta_DM0_DOWN=svFitEta;
-              svFitPhi_DM0_DOWN=svFitPhi;
-              svFitMET_DM0_DOWN=svFitMET;
-              svFitTransverseMass_DM0_DOWN=svFitTransverseMass;
+              svFitMass_DM0_Down=svFitMass;
+              svFitPt_DM0_Down=svFitPt;
+              svFitEta_DM0_Down=svFitEta;
+              svFitPhi_DM0_Down=svFitPhi;
+              svFitMET_DM0_Down=svFitMET;
+              svFitTransverseMass_DM0_Down=svFitTransverseMass;
               tau1_DM0_down = tau1;
               tau2_DM0_down = tau2;
             }
@@ -1007,15 +1007,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM1 shifted down
             if (gen_match_2 == 5 && decayMode2 == 1) {
               std::cout << "DM1 shift down" << std::endl;
-              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, 
-                    svFitEta_DM1_DOWN, svFitPhi_DM1_DOWN, svFitMET_DM1_DOWN, svFitTransverseMass_DM1_DOWN, tau1_DM1_down, tau2_DM1_down);
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_DM1_Down, svFitPt_DM1_Down, 
+                    svFitEta_DM1_Down, svFitPhi_DM1_Down, svFitMET_DM1_Down, svFitTransverseMass_DM1_Down, tau1_DM1_down, tau2_DM1_down);
             } else {
-              svFitMass_DM1_DOWN=svFitMass;
-              svFitPt_DM1_DOWN=svFitPt;
-              svFitEta_DM1_DOWN=svFitEta;
-              svFitPhi_DM1_DOWN=svFitPhi;
-              svFitMET_DM1_DOWN=svFitMET;
-              svFitTransverseMass_DM1_DOWN=svFitTransverseMass;
+              svFitMass_DM1_Down=svFitMass;
+              svFitPt_DM1_Down=svFitPt;
+              svFitEta_DM1_Down=svFitEta;
+              svFitPhi_DM1_Down=svFitPhi;
+              svFitMET_DM1_Down=svFitMET;
+              svFitTransverseMass_DM1_Down=svFitTransverseMass;
               tau1_DM1_down = tau1;
               tau2_DM1_down = tau2;
             }
@@ -1023,15 +1023,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM10 shifted down
             if (gen_match_2 == 5 && decayMode2 == 10) {
               std::cout << "DM10 shift down" << std::endl;
-              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, 
-                    svFitEta_DM10_DOWN, svFitPhi_DM10_DOWN, svFitMET_DM10_DOWN, svFitTransverseMass_DM10_DOWN, tau1_DM10_down, tau2_DM10_down);
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_DM10_Down, svFitPt_DM10_Down, 
+                    svFitEta_DM10_Down, svFitPhi_DM10_Down, svFitMET_DM10_Down, svFitTransverseMass_DM10_Down, tau1_DM10_down, tau2_DM10_down);
             } else {
-              svFitMass_DM10_DOWN=svFitMass;
-              svFitPt_DM10_DOWN=svFitPt;
-              svFitEta_DM10_DOWN=svFitEta;
-              svFitPhi_DM10_DOWN=svFitPhi;
-              svFitMET_DM10_DOWN=svFitMET;
-              svFitTransverseMass_DM10_DOWN=svFitTransverseMass;
+              svFitMass_DM10_Down=svFitMass;
+              svFitPt_DM10_Down=svFitPt;
+              svFitEta_DM10_Down=svFitEta;
+              svFitPhi_DM10_Down=svFitPhi;
+              svFitMET_DM10_Down=svFitMET;
+              svFitTransverseMass_DM10_Down=svFitTransverseMass;
               tau1_DM10_down = tau1;
               tau2_DM10_down = tau2;
             }
@@ -1053,55 +1053,55 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          // 1% shift in barrel and 2.5% shift in endcap
          // applied to electrons in emu channel
          float etaBarrelEndcap  = 1.479;
-         float ES_UP_scale;
-         if (abs(eta1) < etaBarrelEndcap) ES_UP_scale = 1.01;
-         else ES_UP_scale = 1.025;
-         double pt1_UP = pt1 * ES_UP_scale;
-         std::cout << "E eta: " << eta1 << " ees SF: " << ES_UP_scale << std::endl;
-         double metcorr_ex_UP, metcorr_ey_UP;
-         double dx1_UP, dy1_UP;
-         dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale ) - 1.);
-         dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale ) - 1.);
-         metcorr_ex_UP = metcorr_ex + dx1_UP;
-         metcorr_ey_UP = metcorr_ey + dy1_UP;
-         std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_UP <<std::endl;
-         std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_UP <<std::endl;
-         std::cout << "pt1 " << pt1 << "  pt1_up " << pt1_UP <<std::endl;
-         std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_UP << std::endl;
-         std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_UP << std::endl;
+         float ES_Up_scale;
+         if (abs(eta1) < etaBarrelEndcap) ES_Up_scale = 1.01;
+         else ES_Up_scale = 1.025;
+         double pt1_Up = pt1 * ES_Up_scale;
+         std::cout << "E eta: " << eta1 << " ees SF: " << ES_Up_scale << std::endl;
+         double metcorr_ex_Up, metcorr_ey_Up;
+         double dx1_Up, dy1_Up;
+         dx1_Up = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Up_scale ) - 1.);
+         dy1_Up = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Up_scale ) - 1.);
+         metcorr_ex_Up = metcorr_ex + dx1_Up;
+         metcorr_ey_Up = metcorr_ey + dy1_Up;
+         std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_Up <<std::endl;
+         std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_Up <<std::endl;
+         std::cout << "pt1 " << pt1 << "  pt1_up " << pt1_Up <<std::endl;
+         std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_Up << std::endl;
+         std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_Up << std::endl;
          
          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1));
          measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2, mass2));
          
-         std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1_UP << " mass1 " << mass1 << " pt2: "<< pt2 << " mass2: "<< mass2 <<std::endl;        
-         runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+         std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1_Up << " mass1 " << mass1 << " pt2: "<< pt2 << " mass2: "<< mass2 <<std::endl;        
+         runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_Up, svFitPt_Up, svFitEta_Up, svFitPhi_Up, svFitMET_Up, svFitTransverseMass_Up, tau1_up, tau2_up);
          std::cout<<"finished runningSVFit in EMu EES Up"<<std::endl;
          
          
          // EES Down
-         float ES_DOWN_scale;
-         if (abs(eta1) < etaBarrelEndcap) ES_DOWN_scale = 0.99;
-         else ES_DOWN_scale = 0.975;
-         std::cout << "E eta: " << eta1 << " ees SF: " << ES_DOWN_scale << std::endl;
-         double pt1_DOWN;
-         pt1_DOWN = pt1 * ES_DOWN_scale;
-         double metcorr_ex_DOWN, metcorr_ey_DOWN;
-         double dx1_DOWN, dy1_DOWN;
-         dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale ) - 1.);
-         dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale ) - 1.);
-         metcorr_ex_DOWN = metcorr_ex + dx1_DOWN;
-         metcorr_ey_DOWN = metcorr_ey + dy1_DOWN;
-         std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_DOWN <<std::endl;
-         std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_DOWN <<std::endl;
-         std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_DOWN << std::endl;
-         std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_DOWN << std::endl;
+         float ES_Down_scale;
+         if (abs(eta1) < etaBarrelEndcap) ES_Down_scale = 0.99;
+         else ES_Down_scale = 0.975;
+         std::cout << "E eta: " << eta1 << " ees SF: " << ES_Down_scale << std::endl;
+         double pt1_Down;
+         pt1_Down = pt1 * ES_Down_scale;
+         double metcorr_ex_Down, metcorr_ey_Down;
+         double dx1_Down, dy1_Down;
+         dx1_Down = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Down_scale ) - 1.);
+         dy1_Down = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Down_scale ) - 1.);
+         metcorr_ex_Down = metcorr_ex + dx1_Down;
+         metcorr_ey_Down = metcorr_ey + dy1_Down;
+         std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_Down <<std::endl;
+         std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_Down <<std::endl;
+         std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_Down << std::endl;
+         std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_Down << std::endl;
          
          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1));
          measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2));
          
-         runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+         runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_Down, svFitPt_Down, svFitEta_Down, svFitPhi_Down, svFitMET_Down, svFitTransverseMass_Down, tau1_down, tau2_down);
          
          
        } // end doES
@@ -1160,19 +1160,19 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
        std::cout << "MET Unclustered Energy Up   ---  ";
        metcorrUncUp_ex = metcorrUncUp_ex + dx1 + dx2;
        metcorrUncUp_ey = metcorrUncUp_ey + dy1 + dy2;
-       runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_UP, svFitPt_UncMet_UP, svFitEta_UncMet_UP, svFitPhi_UncMet_UP, svFitMET_UncMet_UP, svFitTransverseMass_UncMet_UP, tau1_UncMet_up, tau2_UncMet_up);
+       runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_Up, svFitPt_UncMet_Up, svFitEta_UncMet_Up, svFitPhi_UncMet_Up, svFitMET_UncMet_Up, svFitTransverseMass_UncMet_Up, tau1_UncMet_up, tau2_UncMet_up);
        std::cout << "MET Unclustered Energy Down ---  ";
        metcorrUncDown_ex = metcorrUncDown_ex + dx1 + dx2;
        metcorrUncDown_ey = metcorrUncDown_ey + dy1 + dy2;
-       runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_DOWN, svFitPt_UncMet_DOWN, svFitEta_UncMet_DOWN, svFitPhi_UncMet_DOWN, svFitMET_UncMet_DOWN, svFitTransverseMass_UncMet_DOWN, tau1_UncMet_down, tau2_UncMet_down);
+       runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_Down, svFitPt_UncMet_Down, svFitEta_UncMet_Down, svFitPhi_UncMet_Down, svFitMET_UncMet_Down, svFitTransverseMass_UncMet_Down, tau1_UncMet_down, tau2_UncMet_down);
        std::cout << "MET Clustered Energy Up     ---  ";
        metcorrClusteredUp_ex = metcorrClusteredUp_ex + dx1 + dx2;
        metcorrClusteredUp_ey = metcorrClusteredUp_ey + dy1 + dy2;
-       runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_UP, svFitPt_ClusteredMet_UP, svFitEta_ClusteredMet_UP, svFitPhi_ClusteredMet_UP, svFitMET_ClusteredMet_UP, svFitTransverseMass_ClusteredMet_UP, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
+       runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_Up, svFitPt_ClusteredMet_Up, svFitEta_ClusteredMet_Up, svFitPhi_ClusteredMet_Up, svFitMET_ClusteredMet_Up, svFitTransverseMass_ClusteredMet_Up, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
        std::cout << "MET Clustered Energy Down   ---  ";
        metcorrClusteredDown_ex = metcorrClusteredDown_ex + dx1 + dx2;
        metcorrClusteredDown_ey = metcorrClusteredDown_ey + dy1 + dy2;
-       runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_DOWN, svFitPt_ClusteredMet_DOWN, svFitEta_ClusteredMet_DOWN, svFitPhi_ClusteredMet_DOWN, svFitMET_ClusteredMet_DOWN, svFitTransverseMass_ClusteredMet_DOWN, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
+       runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_Down, svFitPt_ClusteredMet_Down, svFitEta_ClusteredMet_Down, svFitPhi_ClusteredMet_Down, svFitMET_ClusteredMet_Down, svFitTransverseMass_ClusteredMet_Down, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
        std::cout<< "Shifted MET Summary:\nmetcorr_ex " << metcorr_ex << "\n --- metcorrUncUp_ex " << metcorrUncUp_ex << " metcorrUncDown_ex " << metcorrUncDown_ex
             << " metcorrClusteredUp_ex " << metcorrClusteredUp_ex << " metcorrClusteredDown_ex " << metcorrClusteredDown_ex << std::endl;
        std::cout<< "metcorr_ey " << metcorr_ey << "\n --- metcorrUncUp_ey " << metcorrUncUp_ey << " metcorrUncDown_ey " << metcorrUncDown_ey
@@ -1199,49 +1199,49 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if (gen_match_2==5 or gen_match_1==5){
            std::cout << "Two UP    ---  ";
-           float ES_UP_scale1 = 1.0;
-           float ES_UP_scale2 = 1.0;
-           if(gen_match_1==5) ES_UP_scale1 = tesUP;
-           if(gen_match_2==5) ES_UP_scale2 = tesUP;
+           float ES_Up_scale1 = 1.0;
+           float ES_Up_scale2 = 1.0;
+           if(gen_match_1==5) ES_Up_scale1 = tesUP;
+           if(gen_match_2==5) ES_Up_scale2 = tesUP;
            std::cout << "TES values: gen1: " << gen_match_1 << "   dm_1: " << decayMode;
-           std::cout << "   tes1: " << ES_UP_scale1;
+           std::cout << "   tes1: " << ES_Up_scale1;
            std::cout << "   gen2: " << gen_match_2 << "   dm_2: " << decayMode2;
-           std::cout << "   tes2: " << ES_UP_scale2 << std::endl;
-           double pt1_UP, pt2_UP;
-           pt1_UP = pt1 * ES_UP_scale1;
-           pt2_UP = pt2 * ES_UP_scale2;
-           double metcorr_ex_UP, metcorr_ey_UP;
-           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           std::cout << "   tes2: " << ES_Up_scale2 << std::endl;
+           double pt1_Up, pt2_Up;
+           pt1_Up = pt1 * ES_Up_scale1;
+           pt2_Up = pt2 * ES_Up_scale2;
+           double metcorr_ex_Up, metcorr_ey_Up;
+           double dx1_Up, dy1_Up, dx2_Up, dy2_Up;
+           dx1_Up = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dy1_Up = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dx2_Up = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           dy2_Up = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           metcorr_ex_Up = metcorr_ex + dx1_Up + dx2_Up;
+           metcorr_ey_Up = metcorr_ey + dy1_Up + dy2_Up;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
            
            // Add Tau of higest Pt first
            if (pt1 > pt2) {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
          
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
          
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_Up, svFitPt_Up, svFitEta_Up, svFitPhi_Up, svFitMET_Up, svFitTransverseMass_Up, tau1_up, tau2_up);
          }
          else {
-           svFitMass_UP=svFitMass;
-           svFitPt_UP=svFitPt;
-           svFitEta_UP=svFitEta;
-           svFitPhi_UP=svFitPhi;
-           svFitMET_UP=svFitMET;
-           svFitTransverseMass_UP=svFitTransverseMass;
+           svFitMass_Up=svFitMass;
+           svFitPt_Up=svFitPt;
+           svFitEta_Up=svFitEta;
+           svFitPhi_Up=svFitPhi;
+           svFitMET_Up=svFitMET;
+           svFitTransverseMass_Up=svFitTransverseMass;
            tau1_up = tau1;
            tau2_up = tau2;
          }
@@ -1252,42 +1252,42 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if ((gen_match_2==5 && decayMode2==0) or (gen_match_1==5 && decayMode==0)){
            std::cout << "DM0 UP    ---  ";
-           float ES_UP_scale1 = 1.0;
-           float ES_UP_scale2 = 1.0;
-           if(gen_match_1==5 && decayMode==0) ES_UP_scale1 = tesUP;
-           if(gen_match_2==5 && decayMode2==0) ES_UP_scale2 = tesUP;
-           double pt1_UP, pt2_UP;
-           pt1_UP = pt1 * ES_UP_scale1;
-           pt2_UP = pt2 * ES_UP_scale2;
-           double metcorr_ex_UP, metcorr_ey_UP;
-           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           float ES_Up_scale1 = 1.0;
+           float ES_Up_scale2 = 1.0;
+           if(gen_match_1==5 && decayMode==0) ES_Up_scale1 = tesUP;
+           if(gen_match_2==5 && decayMode2==0) ES_Up_scale2 = tesUP;
+           double pt1_Up, pt2_Up;
+           pt1_Up = pt1 * ES_Up_scale1;
+           pt2_Up = pt2 * ES_Up_scale2;
+           double metcorr_ex_Up, metcorr_ey_Up;
+           double dx1_Up, dy1_Up, dx2_Up, dy2_Up;
+           dx1_Up = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dy1_Up = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dx2_Up = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           dy2_Up = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           metcorr_ex_Up = metcorr_ex + dx1_Up + dx2_Up;
+           metcorr_ey_Up = metcorr_ey + dy1_Up + dy2_Up;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
            // Add Tau of higest Pt first
            if (pt1 > pt2) {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM0_UP, svFitPt_DM0_UP, svFitEta_DM0_UP, svFitPhi_DM0_UP, svFitMET_DM0_UP, svFitTransverseMass_DM0_UP, tau1_DM0_up, tau2_DM0_down);
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_DM0_Up, svFitPt_DM0_Up, svFitEta_DM0_Up, svFitPhi_DM0_Up, svFitMET_DM0_Up, svFitTransverseMass_DM0_Up, tau1_DM0_up, tau2_DM0_up);
          }
          else {
-           svFitMass_DM0_UP=svFitMass;
-           svFitPt_DM0_UP=svFitPt;
-           svFitEta_DM0_UP=svFitEta;
-           svFitPhi_DM0_UP=svFitPhi;
-           svFitMET_DM0_UP=svFitMET;
-           svFitTransverseMass_DM0_UP=svFitTransverseMass;
+           svFitMass_DM0_Up=svFitMass;
+           svFitPt_DM0_Up=svFitPt;
+           svFitEta_DM0_Up=svFitEta;
+           svFitPhi_DM0_Up=svFitPhi;
+           svFitMET_DM0_Up=svFitMET;
+           svFitTransverseMass_DM0_Up=svFitTransverseMass;
            tau1_DM0_up = tau1;
            tau2_DM0_down = tau2;
          }
@@ -1298,41 +1298,41 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if ((decayMode==1 && gen_match_1==5) or (decayMode2==1 && gen_match_2==5)){
            std::cout << "DM1 UP    ---  ";
-           float ES_UP_scale1 = 1.0;
-           float ES_UP_scale2 = 1.0;
-           if (decayMode==1 && gen_match_1==5) ES_UP_scale1 = tesUP;
-           if (decayMode2==1 && gen_match_2==5) ES_UP_scale2 = tesUP;
-           double pt1_UP, pt2_UP;
-           pt1_UP = pt1 * ES_UP_scale1;
-           pt2_UP = pt2 * ES_UP_scale2;
-           double metcorr_ex_UP, metcorr_ey_UP;
-           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           float ES_Up_scale1 = 1.0;
+           float ES_Up_scale2 = 1.0;
+           if (decayMode==1 && gen_match_1==5) ES_Up_scale1 = tesUP;
+           if (decayMode2==1 && gen_match_2==5) ES_Up_scale2 = tesUP;
+           double pt1_Up, pt2_Up;
+           pt1_Up = pt1 * ES_Up_scale1;
+           pt2_Up = pt2 * ES_Up_scale2;
+           double metcorr_ex_Up, metcorr_ey_Up;
+           double dx1_Up, dy1_Up, dx2_Up, dy2_Up;
+           dx1_Up = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dy1_Up = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dx2_Up = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           dy2_Up = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           metcorr_ex_Up = metcorr_ex + dx1_Up + dx2_Up;
+           metcorr_ey_Up = metcorr_ey + dy1_Up + dy2_Up;
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
            // Add Tau of higest Pt first
            if (pt1 > pt2) {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, svFitEta_DM1_UP, svFitPhi_DM1_UP, svFitMET_DM1_UP, svFitTransverseMass_DM1_UP, tau1_DM1_up, tau2_DM1_up);
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_DM1_Up, svFitPt_DM1_Up, svFitEta_DM1_Up, svFitPhi_DM1_Up, svFitMET_DM1_Up, svFitTransverseMass_DM1_Up, tau1_DM1_up, tau2_DM1_up);
          }
          else {
-           svFitMass_DM1_UP=svFitMass;
-           svFitPt_DM1_UP=svFitPt;
-           svFitEta_DM1_UP=svFitEta;
-           svFitPhi_DM1_UP=svFitPhi;
-           svFitMET_DM1_UP=svFitMET;
-           svFitTransverseMass_DM1_UP=svFitTransverseMass;
+           svFitMass_DM1_Up=svFitMass;
+           svFitPt_DM1_Up=svFitPt;
+           svFitEta_DM1_Up=svFitEta;
+           svFitPhi_DM1_Up=svFitPhi;
+           svFitMET_DM1_Up=svFitMET;
+           svFitTransverseMass_DM1_Up=svFitTransverseMass;
            tau1_DM1_up = tau1;
            tau2_DM1_up = tau2;
          }
@@ -1343,43 +1343,43 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if ((decayMode2==10 && gen_match_2==5) or (decayMode==10 && gen_match_1==5)){
            std::cout << "DM10 UP    ---  ";
-           float ES_UP_scale1 = 1.0;
-           float ES_UP_scale2 = 1.0;
-           if(decayMode==10 && gen_match_1==5) ES_UP_scale1 = tesUP;
-           if(decayMode2==10 && gen_match_2==5) ES_UP_scale2 = tesUP;
-           double pt1_UP, pt2_UP;
-           pt1_UP = pt1 * ES_UP_scale1;
-           pt2_UP = pt2 * ES_UP_scale2;
-           double metcorr_ex_UP, metcorr_ey_UP;
-           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           float ES_Up_scale1 = 1.0;
+           float ES_Up_scale2 = 1.0;
+           if(decayMode==10 && gen_match_1==5) ES_Up_scale1 = tesUP;
+           if(decayMode2==10 && gen_match_2==5) ES_Up_scale2 = tesUP;
+           double pt1_Up, pt2_Up;
+           pt1_Up = pt1 * ES_Up_scale1;
+           pt2_Up = pt2 * ES_Up_scale2;
+           double metcorr_ex_Up, metcorr_ey_Up;
+           double dx1_Up, dy1_Up, dx2_Up, dy2_Up;
+           dx1_Up = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dy1_Up = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Up_scale1 ) - 1.);
+           dx2_Up = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           dy2_Up = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Up_scale2 ) - 1.);
+           metcorr_ex_Up = metcorr_ex + dx1_Up + dx2_Up;
+           metcorr_ey_Up = metcorr_ey + dy1_Up + dy2_Up;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
            
            // Add Tau of higest Pt first
            if (pt1 > pt2) {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Up, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Up, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, svFitEta_DM10_UP, svFitPhi_DM10_UP, svFitMET_DM10_UP, svFitTransverseMass_DM10_UP, tau1_DM10_up, tau2_DM10_up);
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_Up, metcorr_ey_Up, covMET, 0, svFitMass_DM10_Up, svFitPt_DM10_Up, svFitEta_DM10_Up, svFitPhi_DM10_Up, svFitMET_DM10_Up, svFitTransverseMass_DM10_Up, tau1_DM10_up, tau2_DM10_up);
          }
          else {
-           svFitMass_DM10_UP=svFitMass;
-           svFitPt_DM10_UP=svFitPt;
-           svFitEta_DM10_UP=svFitEta;
-           svFitPhi_DM10_UP=svFitPhi;
-           svFitMET_DM10_UP=svFitMET;
-           svFitTransverseMass_DM10_UP=svFitTransverseMass;
+           svFitMass_DM10_Up=svFitMass;
+           svFitPt_DM10_Up=svFitPt;
+           svFitEta_DM10_Up=svFitEta;
+           svFitPhi_DM10_Up=svFitPhi;
+           svFitMET_DM10_Up=svFitMET;
+           svFitTransverseMass_DM10_Up=svFitTransverseMass;
            tau1_DM10_up = tau1;
            tau2_DM10_up = tau2;
          }
@@ -1390,42 +1390,42 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if (gen_match_1==5 or gen_match_2==5){
            std::cout << "Two DOWN  ---  ";
-           float ES_DOWN_scale1 = 1.0;
-           float ES_DOWN_scale2 = 1.0;
-           if (gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-           if (gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-           double pt1_DOWN, pt2_DOWN;
-           pt1_DOWN = pt1 * ES_DOWN_scale1;
-           pt2_DOWN = pt2 * ES_DOWN_scale2;
-           double metcorr_ex_DOWN, metcorr_ey_DOWN;
-           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           float ES_Down_scale1 = 1.0;
+           float ES_Down_scale2 = 1.0;
+           if (gen_match_1==5) ES_Down_scale1 = tesDOWN;
+           if (gen_match_2==5) ES_Down_scale2 = tesDOWN;
+           double pt1_Down, pt2_Down;
+           pt1_Down = pt1 * ES_Down_scale1;
+           pt2_Down = pt2 * ES_Down_scale2;
+           double metcorr_ex_Down, metcorr_ey_Down;
+           double dx1_Down, dy1_Down, dx2_Down, dy2_Down;
+           dx1_Down = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dy1_Down = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dx2_Down = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           dy2_Down = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           metcorr_ex_Down = metcorr_ex + dx1_Down + dx2_Down;
+           metcorr_ey_Down = metcorr_ey + dy1_Down + dy2_Down;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
            
            if (pt1 > pt2) {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_Down, svFitPt_Down, svFitEta_Down, svFitPhi_Down, svFitMET_Down, svFitTransverseMass_Down, tau1_down, tau2_down);
          }
          else {
-           svFitMass_DOWN=svFitMass;
-           svFitPt_DOWN=svFitPt;
-           svFitEta_DOWN=svFitEta;
-           svFitPhi_DOWN=svFitPhi;
-           svFitMET_DOWN=svFitMET;
-           svFitTransverseMass_DOWN=svFitTransverseMass;
+           svFitMass_Down=svFitMass;
+           svFitPt_Down=svFitPt;
+           svFitEta_Down=svFitEta;
+           svFitPhi_Down=svFitPhi;
+           svFitMET_Down=svFitMET;
+           svFitTransverseMass_Down=svFitTransverseMass;
            tau1_down = tau1;
            tau2_down = tau2;
          }
@@ -1436,41 +1436,41 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if ((decayMode==0 && gen_match_1==5) or (decayMode2==0 && gen_match_2==5)){
            std::cout << "DM0 DOWN  ---  ";
-           float ES_DOWN_scale1 = 1.0;
-           float ES_DOWN_scale2 = 1.0;
-           if (decayMode==0 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-           if (decayMode2==0 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-           double pt1_DOWN, pt2_DOWN;
-           pt1_DOWN = pt1 * ES_DOWN_scale1;
-           pt2_DOWN = pt2 * ES_DOWN_scale2;
-           double metcorr_ex_DOWN, metcorr_ey_DOWN;
-           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           float ES_Down_scale1 = 1.0;
+           float ES_Down_scale2 = 1.0;
+           if (decayMode==0 && gen_match_1==5) ES_Down_scale1 = tesDOWN;
+           if (decayMode2==0 && gen_match_2==5) ES_Down_scale2 = tesDOWN;
+           double pt1_Down, pt2_Down;
+           pt1_Down = pt1 * ES_Down_scale1;
+           pt2_Down = pt2 * ES_Down_scale2;
+           double metcorr_ex_Down, metcorr_ey_Down;
+           double dx1_Down, dy1_Down, dx2_Down, dy2_Down;
+           dx1_Down = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dy1_Down = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dx2_Down = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           dy2_Down = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           metcorr_ex_Down = metcorr_ex + dx1_Down + dx2_Down;
+           metcorr_ey_Down = metcorr_ey + dy1_Down + dy2_Down;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
            if (pt1 > pt2) {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM0_DOWN, svFitPt_DM0_DOWN, svFitEta_DM0_DOWN, svFitPhi_DM0_DOWN, svFitMET_DM0_DOWN, svFitTransverseMass_DM0_DOWN, tau1_DM0_down, tau2_DM0_down);
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_DM0_Down, svFitPt_DM0_Down, svFitEta_DM0_Down, svFitPhi_DM0_Down, svFitMET_DM0_Down, svFitTransverseMass_DM0_Down, tau1_DM0_down, tau2_DM0_down);
          }
          else {
-           svFitMass_DM0_DOWN=svFitMass;
-           svFitPt_DM0_DOWN=svFitPt;
-           svFitEta_DM0_DOWN=svFitEta;
-           svFitPhi_DM0_DOWN=svFitPhi;
-           svFitMET_DM0_DOWN=svFitMET;
-           svFitTransverseMass_DM0_DOWN=svFitTransverseMass;
+           svFitMass_DM0_Down=svFitMass;
+           svFitPt_DM0_Down=svFitPt;
+           svFitEta_DM0_Down=svFitEta;
+           svFitPhi_DM0_Down=svFitPhi;
+           svFitMET_DM0_Down=svFitMET;
+           svFitTransverseMass_DM0_Down=svFitTransverseMass;
            tau1_DM0_down = tau1;
            tau2_DM0_down = tau2;
          }
@@ -1481,42 +1481,42 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if ((decayMode==1 && gen_match_1==5) or (decayMode2==1 && gen_match_2==5)){
            std::cout << "DM1 DOWN  ---  ";
-           float ES_DOWN_scale1 = 1.0;
-           float ES_DOWN_scale2 = 1.0;
-           if (decayMode==1 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-           if (decayMode2==1 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-           double pt1_DOWN, pt2_DOWN;
-           pt1_DOWN = pt1 * ES_DOWN_scale1;
-           pt2_DOWN = pt2 * ES_DOWN_scale2;
-           double metcorr_ex_DOWN, metcorr_ey_DOWN;
-           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           float ES_Down_scale1 = 1.0;
+           float ES_Down_scale2 = 1.0;
+           if (decayMode==1 && gen_match_1==5) ES_Down_scale1 = tesDOWN;
+           if (decayMode2==1 && gen_match_2==5) ES_Down_scale2 = tesDOWN;
+           double pt1_Down, pt2_Down;
+           pt1_Down = pt1 * ES_Down_scale1;
+           pt2_Down = pt2 * ES_Down_scale2;
+           double metcorr_ex_Down, metcorr_ey_Down;
+           double dx1_Down, dy1_Down, dx2_Down, dy2_Down;
+           dx1_Down = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dy1_Down = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dx2_Down = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           dy2_Down = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           metcorr_ex_Down = metcorr_ex + dx1_Down + dx2_Down;
+           metcorr_ey_Down = metcorr_ey + dy1_Down + dy2_Down;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
            
            if (pt1 > pt2) {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, svFitEta_DM1_DOWN, svFitPhi_DM1_DOWN, svFitMET_DM1_DOWN, svFitTransverseMass_DM1_DOWN, tau1_DM1_down, tau2_DM1_down);
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_DM1_Down, svFitPt_DM1_Down, svFitEta_DM1_Down, svFitPhi_DM1_Down, svFitMET_DM1_Down, svFitTransverseMass_DM1_Down, tau1_DM1_down, tau2_DM1_down);
          }
          else {
-           svFitMass_DM1_DOWN=svFitMass;
-           svFitPt_DM1_DOWN=svFitPt;
-           svFitEta_DM1_DOWN=svFitEta;
-           svFitPhi_DM1_DOWN=svFitPhi;
-           svFitMET_DM1_DOWN=svFitMET;
-           svFitTransverseMass_DM1_DOWN=svFitTransverseMass;
+           svFitMass_DM1_Down=svFitMass;
+           svFitPt_DM1_Down=svFitPt;
+           svFitEta_DM1_Down=svFitEta;
+           svFitPhi_DM1_Down=svFitPhi;
+           svFitMET_DM1_Down=svFitMET;
+           svFitTransverseMass_DM1_Down=svFitTransverseMass;
            tau1_DM1_down =  tau1;
            tau2_DM1_down =  tau2;
          }
@@ -1527,41 +1527,41 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
          
          if ((decayMode==10 && gen_match_1==5) or (decayMode2==10 && gen_match_2==5)){
            std::cout << "DM10 DOWN  ---  ";
-           float ES_DOWN_scale1 = 1.0;
-           float ES_DOWN_scale2 = 1.0;
-           if (decayMode==10 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-           if (decayMode2==10 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-           double pt1_DOWN, pt2_DOWN;
-           pt1_DOWN = pt1 * ES_DOWN_scale1;
-           pt2_DOWN = pt2 * ES_DOWN_scale2;
-           double metcorr_ex_DOWN, metcorr_ey_DOWN;
-           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           float ES_Down_scale1 = 1.0;
+           float ES_Down_scale2 = 1.0;
+           if (decayMode==10 && gen_match_1==5) ES_Down_scale1 = tesDOWN;
+           if (decayMode2==10 && gen_match_2==5) ES_Down_scale2 = tesDOWN;
+           double pt1_Down, pt2_Down;
+           pt1_Down = pt1 * ES_Down_scale1;
+           pt2_Down = pt2 * ES_Down_scale2;
+           double metcorr_ex_Down, metcorr_ey_Down;
+           double dx1_Down, dy1_Down, dx2_Down, dy2_Down;
+           dx1_Down = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dy1_Down = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_Down_scale1 ) - 1.);
+           dx2_Down = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           dy2_Down = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_Down_scale2 ) - 1.);
+           metcorr_ex_Down = metcorr_ex + dx1_Down + dx2_Down;
+           metcorr_ey_Down = metcorr_ey + dy1_Down + dy2_Down;
            
            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
            if (pt1 > pt2) {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_Down, eta2, phi2,  mass2, decayMode2));
            }
            else {
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2, pt2_DOWN, eta2, phi2, mass2, decayMode2));
-         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1, phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2, pt2_Down, eta2, phi2, mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_Down, eta1, phi1, mass1, decayMode));
            }
            
-           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, svFitEta_DM10_DOWN, svFitPhi_DM10_DOWN, svFitMET_DM10_DOWN, svFitTransverseMass_DM10_DOWN, tau1_DM10_down, tau2_DM10_down);
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_Down, metcorr_ey_Down, covMET, 0, svFitMass_DM10_Down, svFitPt_DM10_Down, svFitEta_DM10_Down, svFitPhi_DM10_Down, svFitMET_DM10_Down, svFitTransverseMass_DM10_Down, tau1_DM10_down, tau2_DM10_down);
          }
          else {
-           svFitMass_DM10_DOWN=svFitMass;
-           svFitPt_DM10_DOWN=svFitPt;
-           svFitEta_DM10_DOWN=svFitEta;
-           svFitPhi_DM10_DOWN=svFitPhi;
-           svFitMET_DM10_DOWN=svFitMET;
-           svFitTransverseMass_DM10_DOWN=svFitTransverseMass;
+           svFitMass_DM10_Down=svFitMass;
+           svFitPt_DM10_Down=svFitPt;
+           svFitEta_DM10_Down=svFitEta;
+           svFitPhi_DM10_Down=svFitPhi;
+           svFitMET_DM10_Down=svFitMET;
+           svFitTransverseMass_DM10_Down=svFitTransverseMass;
            tau1_DM10_down = tau1;
            tau2_DM10_down = tau2;
          }
@@ -1589,113 +1589,113 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
      tau2_phi = tau2.Phi();
      tau2_m   = tau2.M();
      // up
-     tau1_pt_UP  = tau1_up.Pt();
-     tau1_eta_UP = tau1_up.Eta();
-     tau1_phi_UP = tau1_up.Phi();
-     tau1_m_UP   = tau1_up.M();
-     tau2_pt_UP  = tau2_up.Pt();
-     tau2_eta_UP = tau2_up.Eta();
-     tau2_phi_UP = tau2_up.Phi();
-     tau2_m_UP   = tau2_up.M();
+     tau1_pt_Up  = tau1_up.Pt();
+     tau1_eta_Up = tau1_up.Eta();
+     tau1_phi_Up = tau1_up.Phi();
+     tau1_m_Up   = tau1_up.M();
+     tau2_pt_Up  = tau2_up.Pt();
+     tau2_eta_Up = tau2_up.Eta();
+     tau2_phi_Up = tau2_up.Phi();
+     tau2_m_Up   = tau2_up.M();
      // down
-     tau1_pt_DOWN  = tau1_down.Pt();
-     tau1_eta_DOWN = tau1_down.Eta();
-     tau1_phi_DOWN = tau1_down.Phi();
-     tau1_m_DOWN   = tau1_down.M();
-     tau2_pt_DOWN  = tau2_down.Pt();
-     tau2_eta_DOWN = tau2_down.Eta();
-     tau2_phi_DOWN = tau2_down.Phi();
-     tau2_m_DOWN   = tau2_down.M();
+     tau1_pt_Down  = tau1_down.Pt();
+     tau1_eta_Down = tau1_down.Eta();
+     tau1_phi_Down = tau1_down.Phi();
+     tau1_m_Down   = tau1_down.M();
+     tau2_pt_Down  = tau2_down.Pt();
+     tau2_eta_Down = tau2_down.Eta();
+     tau2_phi_Down = tau2_down.Phi();
+     tau2_m_Down   = tau2_down.M();
      // DM0 up
-     tau1_pt_DM0_UP  = tau1_DM0_up.Pt();
-     tau1_eta_DM0_UP = tau1_DM0_up.Eta();
-     tau1_phi_DM0_UP = tau1_DM0_up.Phi();
-     tau1_m_DM0_UP   = tau1_DM0_up.M();
-     tau2_pt_DM0_UP  = tau2_DM0_up.Pt();
-     tau2_eta_DM0_UP = tau2_DM0_up.Eta();
-     tau2_phi_DM0_UP = tau2_DM0_up.Phi();
-     tau2_m_DM0_UP   = tau2_DM0_up.M();
+     tau1_pt_DM0_Up  = tau1_DM0_up.Pt();
+     tau1_eta_DM0_Up = tau1_DM0_up.Eta();
+     tau1_phi_DM0_Up = tau1_DM0_up.Phi();
+     tau1_m_DM0_Up   = tau1_DM0_up.M();
+     tau2_pt_DM0_Up  = tau2_DM0_up.Pt();
+     tau2_eta_DM0_Up = tau2_DM0_up.Eta();
+     tau2_phi_DM0_Up = tau2_DM0_up.Phi();
+     tau2_m_DM0_Up   = tau2_DM0_up.M();
      // down
-     tau1_pt_DM0_DOWN  = tau1_DM0_down.Pt();
-     tau1_eta_DM0_DOWN = tau1_DM0_down.Eta();
-     tau1_phi_DM0_DOWN = tau1_DM0_down.Phi();
-     tau1_m_DM0_DOWN   = tau1_DM0_down.M();
-     tau2_pt_DM0_DOWN  = tau2_DM0_down.Pt();
-     tau2_eta_DM0_DOWN = tau2_DM0_down.Eta();
-     tau2_phi_DM0_DOWN = tau2_DM0_down.Phi();
-     tau2_m_DM0_DOWN   = tau2_DM0_down.M();
+     tau1_pt_DM0_Down  = tau1_DM0_down.Pt();
+     tau1_eta_DM0_Down = tau1_DM0_down.Eta();
+     tau1_phi_DM0_Down = tau1_DM0_down.Phi();
+     tau1_m_DM0_Down   = tau1_DM0_down.M();
+     tau2_pt_DM0_Down  = tau2_DM0_down.Pt();
+     tau2_eta_DM0_Down = tau2_DM0_down.Eta();
+     tau2_phi_DM0_Down = tau2_DM0_down.Phi();
+     tau2_m_DM0_Down   = tau2_DM0_down.M();
      // DM1 up
-     tau1_pt_DM1_UP  = tau1_DM1_up.Pt();
-     tau1_eta_DM1_UP = tau1_DM1_up.Eta();
-     tau1_phi_DM1_UP = tau1_DM1_up.Phi();
-     tau1_m_DM1_UP   = tau1_DM1_up.M();
-     tau2_pt_DM1_UP  = tau2_DM1_up.Pt();
-     tau2_eta_DM1_UP = tau2_DM1_up.Eta();
-     tau2_phi_DM1_UP = tau2_DM1_up.Phi();
-     tau2_m_DM1_UP   = tau2_DM1_up.M();
+     tau1_pt_DM1_Up  = tau1_DM1_up.Pt();
+     tau1_eta_DM1_Up = tau1_DM1_up.Eta();
+     tau1_phi_DM1_Up = tau1_DM1_up.Phi();
+     tau1_m_DM1_Up   = tau1_DM1_up.M();
+     tau2_pt_DM1_Up  = tau2_DM1_up.Pt();
+     tau2_eta_DM1_Up = tau2_DM1_up.Eta();
+     tau2_phi_DM1_Up = tau2_DM1_up.Phi();
+     tau2_m_DM1_Up   = tau2_DM1_up.M();
      // down
-     tau1_pt_DM1_DOWN  = tau1_DM1_down.Pt();
-     tau1_eta_DM1_DOWN = tau1_DM1_down.Eta();
-     tau1_phi_DM1_DOWN = tau1_DM1_down.Phi();
-     tau1_m_DM1_DOWN   = tau1_DM1_down.M();
-     tau2_pt_DM1_DOWN  = tau2_DM1_down.Pt();
-     tau2_eta_DM1_DOWN = tau2_DM1_down.Eta();
-     tau2_phi_DM1_DOWN = tau2_DM1_down.Phi();
-     tau2_m_DM1_DOWN   = tau2_DM1_down.M();
+     tau1_pt_DM1_Down  = tau1_DM1_down.Pt();
+     tau1_eta_DM1_Down = tau1_DM1_down.Eta();
+     tau1_phi_DM1_Down = tau1_DM1_down.Phi();
+     tau1_m_DM1_Down   = tau1_DM1_down.M();
+     tau2_pt_DM1_Down  = tau2_DM1_down.Pt();
+     tau2_eta_DM1_Down = tau2_DM1_down.Eta();
+     tau2_phi_DM1_Down = tau2_DM1_down.Phi();
+     tau2_m_DM1_Down   = tau2_DM1_down.M();
      // DM10 up
-     tau1_pt_DM10_UP  = tau1_DM10_up.Pt();
-     tau1_eta_DM10_UP = tau1_DM10_up.Eta();
-     tau1_phi_DM10_UP = tau1_DM10_up.Phi();
-     tau1_m_DM10_UP   = tau1_DM10_up.M();
-     tau2_pt_DM10_UP  = tau2_DM10_up.Pt();
-     tau2_eta_DM10_UP = tau2_DM10_up.Eta();
-     tau2_phi_DM10_UP = tau2_DM10_up.Phi();
-     tau2_m_DM10_UP   = tau2_DM10_up.M();
+     tau1_pt_DM10_Up  = tau1_DM10_up.Pt();
+     tau1_eta_DM10_Up = tau1_DM10_up.Eta();
+     tau1_phi_DM10_Up = tau1_DM10_up.Phi();
+     tau1_m_DM10_Up   = tau1_DM10_up.M();
+     tau2_pt_DM10_Up  = tau2_DM10_up.Pt();
+     tau2_eta_DM10_Up = tau2_DM10_up.Eta();
+     tau2_phi_DM10_Up = tau2_DM10_up.Phi();
+     tau2_m_DM10_Up   = tau2_DM10_up.M();
      // down
-     tau1_pt_DM10_DOWN  = tau1_DM10_down.Pt();
-     tau1_eta_DM10_DOWN = tau1_DM10_down.Eta();
-     tau1_phi_DM10_DOWN = tau1_DM10_down.Phi();
-     tau1_m_DM10_DOWN   = tau1_DM10_down.M();
-     tau2_pt_DM10_DOWN  = tau2_DM10_down.Pt();
-     tau2_eta_DM10_DOWN = tau2_DM10_down.Eta();
-     tau2_phi_DM10_DOWN = tau2_DM10_down.Phi();
-     tau2_m_DM10_DOWN   = tau2_DM10_down.M();
+     tau1_pt_DM10_Down  = tau1_DM10_down.Pt();
+     tau1_eta_DM10_Down = tau1_DM10_down.Eta();
+     tau1_phi_DM10_Down = tau1_DM10_down.Phi();
+     tau1_m_DM10_Down   = tau1_DM10_down.M();
+     tau2_pt_DM10_Down  = tau2_DM10_down.Pt();
+     tau2_eta_DM10_Down = tau2_DM10_down.Eta();
+     tau2_phi_DM10_Down = tau2_DM10_down.Phi();
+     tau2_m_DM10_Down   = tau2_DM10_down.M();
      // UncMet up
-     tau1_pt_UncMet_UP  = tau1_UncMet_up.Pt();
-     tau1_eta_UncMet_UP = tau1_UncMet_up.Eta();
-     tau1_phi_UncMet_UP = tau1_UncMet_up.Phi();
-     tau1_m_UncMet_UP   = tau1_UncMet_up.M();
-     tau2_pt_UncMet_UP  = tau2_UncMet_up.Pt();
-     tau2_eta_UncMet_UP = tau2_UncMet_up.Eta();
-     tau2_phi_UncMet_UP = tau2_UncMet_up.Phi();
-     tau2_m_UncMet_UP   = tau2_UncMet_up.M();
+     tau1_pt_UncMet_Up  = tau1_UncMet_up.Pt();
+     tau1_eta_UncMet_Up = tau1_UncMet_up.Eta();
+     tau1_phi_UncMet_Up = tau1_UncMet_up.Phi();
+     tau1_m_UncMet_Up   = tau1_UncMet_up.M();
+     tau2_pt_UncMet_Up  = tau2_UncMet_up.Pt();
+     tau2_eta_UncMet_Up = tau2_UncMet_up.Eta();
+     tau2_phi_UncMet_Up = tau2_UncMet_up.Phi();
+     tau2_m_UncMet_Up   = tau2_UncMet_up.M();
      // down
-     tau1_pt_UncMet_DOWN  = tau1_UncMet_down.Pt();
-     tau1_eta_UncMet_DOWN = tau1_UncMet_down.Eta();
-     tau1_phi_UncMet_DOWN = tau1_UncMet_down.Phi();
-     tau1_m_UncMet_DOWN   = tau1_UncMet_down.M();
-     tau2_pt_UncMet_DOWN  = tau2_UncMet_down.Pt();
-     tau2_eta_UncMet_DOWN = tau2_UncMet_down.Eta();
-     tau2_phi_UncMet_DOWN = tau2_UncMet_down.Phi();
-     tau2_m_UncMet_DOWN   = tau2_UncMet_down.M();
+     tau1_pt_UncMet_Down  = tau1_UncMet_down.Pt();
+     tau1_eta_UncMet_Down = tau1_UncMet_down.Eta();
+     tau1_phi_UncMet_Down = tau1_UncMet_down.Phi();
+     tau1_m_UncMet_Down   = tau1_UncMet_down.M();
+     tau2_pt_UncMet_Down  = tau2_UncMet_down.Pt();
+     tau2_eta_UncMet_Down = tau2_UncMet_down.Eta();
+     tau2_phi_UncMet_Down = tau2_UncMet_down.Phi();
+     tau2_m_UncMet_Down   = tau2_UncMet_down.M();
      // UnclusteredMet up
-     tau1_pt_ClusteredMet_UP  = tau1_ClusteredMet_up.Pt();
-     tau1_eta_ClusteredMet_UP = tau1_ClusteredMet_up.Eta();
-     tau1_phi_ClusteredMet_UP = tau1_ClusteredMet_up.Phi();
-     tau1_m_ClusteredMet_UP   = tau1_ClusteredMet_up.M();
-     tau2_pt_ClusteredMet_UP  = tau2_ClusteredMet_up.Pt();
-     tau2_eta_ClusteredMet_UP = tau2_ClusteredMet_up.Eta();
-     tau2_phi_ClusteredMet_UP = tau2_ClusteredMet_up.Phi();
-     tau2_m_ClusteredMet_UP   = tau2_ClusteredMet_up.M();
+     tau1_pt_ClusteredMet_Up  = tau1_ClusteredMet_up.Pt();
+     tau1_eta_ClusteredMet_Up = tau1_ClusteredMet_up.Eta();
+     tau1_phi_ClusteredMet_Up = tau1_ClusteredMet_up.Phi();
+     tau1_m_ClusteredMet_Up   = tau1_ClusteredMet_up.M();
+     tau2_pt_ClusteredMet_Up  = tau2_ClusteredMet_up.Pt();
+     tau2_eta_ClusteredMet_Up = tau2_ClusteredMet_up.Eta();
+     tau2_phi_ClusteredMet_Up = tau2_ClusteredMet_up.Phi();
+     tau2_m_ClusteredMet_Up   = tau2_ClusteredMet_up.M();
      // down
-     tau1_pt_ClusteredMet_DOWN  = tau1_ClusteredMet_down.Pt();
-     tau1_eta_ClusteredMet_DOWN = tau1_ClusteredMet_down.Eta();
-     tau1_phi_ClusteredMet_DOWN = tau1_ClusteredMet_down.Phi();
-     tau1_m_ClusteredMet_DOWN   = tau1_ClusteredMet_down.M();
-     tau2_pt_ClusteredMet_DOWN  = tau2_ClusteredMet_down.Pt();
-     tau2_eta_ClusteredMet_DOWN = tau2_ClusteredMet_down.Eta();
-     tau2_phi_ClusteredMet_DOWN = tau2_ClusteredMet_down.Phi();
-     tau2_m_ClusteredMet_DOWN   = tau2_ClusteredMet_down.M();
+     tau1_pt_ClusteredMet_Down  = tau1_ClusteredMet_down.Pt();
+     tau1_eta_ClusteredMet_Down = tau1_ClusteredMet_down.Eta();
+     tau1_phi_ClusteredMet_Down = tau1_ClusteredMet_down.Phi();
+     tau1_m_ClusteredMet_Down   = tau1_ClusteredMet_down.M();
+     tau2_pt_ClusteredMet_Down  = tau2_ClusteredMet_down.Pt();
+     tau2_eta_ClusteredMet_Down = tau2_ClusteredMet_down.Eta();
+     tau2_phi_ClusteredMet_Down = tau2_ClusteredMet_down.Phi();
+     tau2_m_ClusteredMet_Down   = tau2_ClusteredMet_down.M();
      
      
      std::cout << "\n\n" << std::endl;

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -735,28 +735,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("metcov10",&pfCovMatrix10);
       t->SetBranchAddress("metcov11",&pfCovMatrix11);
       // Met Unc
-      /*
-      if ( channel ==  "tt" ) {
-        t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnUp",&uncMetPtUp);
-        t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnDown",&uncMetPtDown);
-        t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnUp",&uncMetPhiUp);
-        t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnDown",&uncMetPhiDown);
-        t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnUp",&clusteredMetPtUp);
-        t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnDown",&clusteredMetPtDown);
-        t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnUp",&clusteredMetPhiUp);
-        t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnDown",&clusteredMetPhiDown);
-      } else  {
-        t->SetBranchAddress("met_UESUp", &uncMetPtUp);
-        t->SetBranchAddress("met_UESDown", &uncMetPtDown);
-        t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);
-        t->SetBranchAddress("metphi_UESDown", &uncMetPhiDown);
-
-        t->SetBranchAddress("met_JESUp", &clusteredMetPtUp);
-        t->SetBranchAddress("met_JESDown", &clusteredMetPtDown);
-        t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
-        t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
-      }
-      */
       t->SetBranchAddress("met_UESUp", &uncMetPtUp);
       t->SetBranchAddress("met_UESDown", &uncMetPtDown);
       t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -19,6 +19,8 @@
 #include "TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
 #include "TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
 
+#include "HTT-utilities/RecoilCorrections/interface/RecoilCorrector.h"
+
 #include "TFile.h"
 #include "TTree.h"
 #include "TH1.h"

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -861,7 +861,44 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
                svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
           std::cout<<"finished runningSVFit"<<std::endl;
 
-          // TODO: MET Systematics 
+          // MET systematics
+          std::cout << "MET Unclustered Energy Up   ---  ";
+          metcorrUncUp_ex = metcorrUncUp_ex + dx2;
+          metcorrUncUp_ey = metcorrUncUp_ey + dy2;
+          runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_UP, svFitPt_UncMet_UP, svFitEta_UncMet_UP, 
+              svFitPhi_UncMet_UP, svFitMET_UncMet_UP, svFitTransverseMass_UncMet_UP, tau1_UncMet_up, tau2_UncMet_up);
+          std::cout << "MET Unclustered Energy Down ---  ";
+          metcorrUncDown_ex = metcorrUncDown_ex + dx2;
+          metcorrUncDown_ey = metcorrUncDown_ey + dy2;
+          runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_DOWN, svFitPt_UncMet_DOWN, svFitEta_UncMet_DOWN, 
+              svFitPhi_UncMet_DOWN, svFitMET_UncMet_DOWN, svFitTransverseMass_UncMet_DOWN, tau1_UncMet_down, tau2_UncMet_down);
+          std::cout << "MET Clustered Energy Up     ---  ";
+          metcorrClusteredUp_ex = metcorrClusteredUp_ex + dx2;
+          metcorrClusteredUp_ey = metcorrClusteredUp_ey + dy2;
+          runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_UP, svFitPt_ClusteredMet_UP, 
+              svFitEta_ClusteredMet_UP, svFitPhi_ClusteredMet_UP, svFitMET_ClusteredMet_UP, svFitTransverseMass_ClusteredMet_UP, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
+          std::cout << "MET Clustered Energy Down   ---  ";
+          metcorrClusteredDown_ex = metcorrClusteredDown_ex + dx2;
+          metcorrClusteredDown_ey = metcorrClusteredDown_ey + dy2;
+          runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_DOWN, svFitPt_ClusteredMet_DOWN, 
+              svFitEta_ClusteredMet_DOWN, svFitPhi_ClusteredMet_DOWN, svFitMET_ClusteredMet_DOWN, svFitTransverseMass_ClusteredMet_DOWN, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
+
+          std::cout<< "Shifted MET Summary:\n\tmetcorr_ex " << metcorr_ex << " --- metcorrUncUp_ex " << metcorrUncUp_ex << " metcorrUncDown_ex " << metcorrUncDown_ex
+              << " metcorrClusteredUp_ex " << metcorrClusteredUp_ex << " metcorrClusteredDown_ex " << metcorrClusteredDown_ex << std::endl;
+          std::cout<< "\tmetcorr_ey " << metcorr_ey << " --- metcorrUncUp_ey " << metcorrUncUp_ey << " metcorrUncDown_ey " << metcorrUncDown_ey
+              << " metcorrClusteredUp_ey " << metcorrClusteredUp_ey << " metcorrClusteredDown_ey " << metcorrClusteredDown_ey << std::endl;
+
+          // new met to store 
+          metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
+          metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
+          metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
+          metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
+          metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
+          metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
+          metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
+          metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
+          metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
+          metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
           
           if(doES) {
             

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -19,17 +19,10 @@
 #include "TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
 #include "TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
 
-#include "HTT-utilities/RecoilCorrections/interface/RecoilCorrector.h"
-
 #include "TFile.h"
 #include "TTree.h"
 #include "TH1.h"
 
-//If recoilType 0 then don't do recoil
-//              FIXME amc@nlo is not ready yet!!! 1 then aMC@NLO DY and W+Jets MC samples
-//                1 is not longer an option
-//              2 MG5 DY and W+Jets MC samples or Higgs MC samples
-//
 //If doES       0 does not apply any ES shifts
 //              1 applies ES shifts to TT channel, no effect on other channels
 //
@@ -40,7 +33,6 @@
 //        -1 use pf met
 
 ClassicSVfit svfitAlgorithm;
-bool tylerCode = false;
 
 void copyFiles( optutl::CommandLineParser parser, TFile* fOld, TFile* fNew) ;
 void readdir(TDirectory *dir, optutl::CommandLineParser parser,  char TreeToUse[], int recoilType, int doES, int isWJets, int metType, double tesSize) ;
@@ -197,7 +189,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 	std::cout << "Identified channel em and using kappa = 3" << std::endl;
 	svfitAlgorithm.addLogM_fixed(true, 3);
       }
-      else if ( std::string(key->GetName()).find("eleTauEvent") != std::string::npos ) {
+      else if ( std::string(key->GetName()).find("et") != std::string::npos ) {
 	std::cout<<"eleTauTree"<<std::endl;
 	decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
 	decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
@@ -743,53 +735,28 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("evt",&evt);
       t->SetBranchAddress("run",&run);
       t->SetBranchAddress("lumi",&lumi);
-      if(channel=="tt" && tylerCode ) {
-        t->SetBranchAddress("t1Pt",&pt1,&pt1branch);
-        t->SetBranchAddress("t1Eta",&eta1);
-        t->SetBranchAddress("t1Phi",&phi1);
-        t->SetBranchAddress("t1Mass",&mass1);
-        t->SetBranchAddress("t1ZTTGenMatching",&gen_match_1);
-        t->SetBranchAddress("t2Pt",&pt2);
-        t->SetBranchAddress("t2Eta",&eta2);
-        t->SetBranchAddress("t2Phi",&phi2);
-        t->SetBranchAddress("t2Mass",&mass2);
-        t->SetBranchAddress("t2ZTTGenMatching",&gen_match_2);
-        t->SetBranchAddress("t1DecayMode",&decayMode);
-        t->SetBranchAddress("t2DecayMode",&decayMode2);
-        t->SetBranchAddress("t1_t2_MvaMetCovMatrix00",&mvaCovMatrix00);
-        t->SetBranchAddress("t1_t2_MvaMetCovMatrix01",&mvaCovMatrix01);
-        t->SetBranchAddress("t1_t2_MvaMetCovMatrix10",&mvaCovMatrix10);
-        t->SetBranchAddress("t1_t2_MvaMetCovMatrix11",&mvaCovMatrix11);
-        t->SetBranchAddress("t1_t2_MvaMet",&mvamet);
-        t->SetBranchAddress("t1_t2_MvaMetPhi",&mvametphi);
-        t->SetBranchAddress("jetVeto30", &njets);
-        t->SetBranchAddress("type1_pfMetEt",&pfmet);
-        t->SetBranchAddress("type1_pfMetPhi",&pfmetphi);
-      }
-      else {
-        t->SetBranchAddress("gen_match_1",&gen_match_1);
-        t->SetBranchAddress("gen_match_2",&gen_match_2);
-	if ( channel == "tt" ) t->SetBranchAddress("t1_decayMode", &decayMode);
-	if ( channel == "tt" ) t->SetBranchAddress("t2_decayMode", &decayMode2);
-        t->SetBranchAddress("pt_1",&pt1,&pt1branch);
-        t->SetBranchAddress("eta_1",&eta1);
-        t->SetBranchAddress("phi_1",&phi1);
-        t->SetBranchAddress("pt_2",&pt2);
-        t->SetBranchAddress("eta_2",&eta2);
-        t->SetBranchAddress("phi_2",&phi2);
-        t->SetBranchAddress("m_2",&m2);
-        //t->SetBranchAddress("l1_decayMode",&decayMode);
-        if ( channel != "tt" ) t->SetBranchAddress("l2_decayMode",&decayMode2);
-        t->SetBranchAddress("mvacov00",&mvaCovMatrix00);
-        t->SetBranchAddress("mvacov01",&mvaCovMatrix01);
-        t->SetBranchAddress("mvacov10",&mvaCovMatrix10);
-        t->SetBranchAddress("mvacov11",&mvaCovMatrix11);
-        t->SetBranchAddress("mvamet",&mvamet);
-        t->SetBranchAddress("mvametphi",&mvametphi);
-        t->SetBranchAddress("njets", &njets);
-        t->SetBranchAddress("met",&pfmet);
-        t->SetBranchAddress("metphi",&pfmetphi);
-      }
+      t->SetBranchAddress("gen_match_1",&gen_match_1);
+      t->SetBranchAddress("gen_match_2",&gen_match_2);
+	  if ( channel == "tt" ) t->SetBranchAddress("t1_decayMode", &decayMode);
+	  if ( channel == "tt" ) t->SetBranchAddress("t2_decayMode", &decayMode2);
+      t->SetBranchAddress("pt_1",&pt1,&pt1branch);
+      t->SetBranchAddress("eta_1",&eta1);
+      t->SetBranchAddress("phi_1",&phi1);
+      t->SetBranchAddress("pt_2",&pt2);
+      t->SetBranchAddress("eta_2",&eta2);
+      t->SetBranchAddress("phi_2",&phi2);
+      t->SetBranchAddress("m_2",&m2);
+      //t->SetBranchAddress("l1_decayMode",&decayMode);
+      if ( channel != "tt" ) t->SetBranchAddress("l2_decayMode",&decayMode2);
+      t->SetBranchAddress("mvacov00",&mvaCovMatrix00);
+      t->SetBranchAddress("mvacov01",&mvaCovMatrix01);
+      t->SetBranchAddress("mvacov10",&mvaCovMatrix10);
+      t->SetBranchAddress("mvacov11",&mvaCovMatrix11);
+      t->SetBranchAddress("mvamet",&mvamet);
+      t->SetBranchAddress("mvametphi",&mvametphi);
+      t->SetBranchAddress("njets", &njets);
+      t->SetBranchAddress("met",&pfmet);
+      t->SetBranchAddress("metphi",&pfmetphi);
       // Recoil variables below
       t->SetBranchAddress( "genpX", &genPx);
       t->SetBranchAddress( "genpY", &genPy);

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -86,20 +86,18 @@ int main (int argc, char* argv[])
     fProduce = new TFile(newFileName.c_str(),"UPDATE");
     std::cout<<"listing the directories================="<<std::endl;
     fProduce->ls();
-    readdir(fProduce,parser,TreeToUse,parser.doubleValue("doES"),
-            parser.doubleValue("isWJets"),parser.doubleValue("metType"),parser.doubleValue("tesSize"));
+    readdir(fProduce,parser,TreeToUse,parser.doubleValue("doES"),parser.doubleValue("isWJets"),
+            parser.doubleValue("metType"),parser.doubleValue("tesSize"));
     
     fProduce->Close();
     f->Close();
   }
   else{
     TFile *f = new TFile(parser.stringValue("inputFile").c_str(),"UPDATE");
-    readdir(f,parser,TreeToUse,parser.doubleValue("doES"),
-            parser.doubleValue("isWJets"),parser.doubleValue("metType"),parser.doubleValue("tesSize"));
+    readdir(f,parser,TreeToUse,parser.doubleValue("doES"),parser.doubleValue("isWJets"),
+            parser.doubleValue("metType"),parser.doubleValue("tesSize"));
     f->Close();
   }
-  
-  
 } 
 
 
@@ -141,8 +139,8 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       dir->cd(key->GetName());
       TDirectory *subdir = gDirectory;
       sprintf(TreeToUse,"%s",key->GetName());
-      readdir(subdir,parser,TreeToUse,parser.doubleValue("doES"),
-	      parser.doubleValue("isWJets"),parser.doubleValue("metType"),parser.doubleValue("tesSize"));
+      readdir(subdir,parser,TreeToUse,parser.doubleValue("doES"),parser.doubleValue("isWJets"),
+          parser.doubleValue("metType"),parser.doubleValue("tesSize"));
       
       dirsav->cd();
     }
@@ -150,55 +148,55 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       // check  if this tree was already processed
       std::vector<TString>::const_iterator it = find(processedNames.begin(), processedNames.end(), key->GetName());
       if ( it != processedNames.end() ) {
-	std::cout << "This tree was already processed, skipping..." <<  std::endl;
-	continue;
+	    std::cout << "This tree was already processed, skipping..." <<  std::endl;
+	    continue;
       }
       std::cout << "This is the tree! Start processing" << std::endl;
       processedNames.push_back(key->GetName());
       
       // Identify the process
       if ( std::string(key->GetName()).find("tt") != std::string::npos )  {
-	decayType1 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	mass1 = 0.13957;
-	mass2 = 0.13957;
-	channel = "tt";
-	std::cout << "Identified channel tt and using kappa = 5" << std::endl;
-	svfitAlgorithm.addLogM_fixed(true, 5);
+	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+	    mass1 = 0.13957;
+	    mass2 = 0.13957;
+	    channel = "tt";
+	    std::cout << "Identified channel tt and using kappa = 5" << std::endl;
+	    svfitAlgorithm.addLogM_fixed(true, 5);
       } 
       else if ( std::string(key->GetName()).find("em") != std::string::npos )  {
-	std::cout<< "EMu sample" <<std::endl;
-	decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
-	decayType2 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
-	mass1 = 0.00051100;
-	mass2 = 0.105658;
-	channel = "em";
-	std::cout << "Identified channel em and using kappa = 3" << std::endl;
-	svfitAlgorithm.addLogM_fixed(true, 3);
+	    std::cout<< "EMu sample" <<std::endl;
+	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
+	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
+	    mass1 = 0.00051100;
+	    mass2 = 0.105658;
+	    channel = "em";
+	    std::cout << "Identified channel em and using kappa = 3" << std::endl;
+	    svfitAlgorithm.addLogM_fixed(true, 3);
       }
       else if ( std::string(key->GetName()).find("et") != std::string::npos ) {
-	std::cout<<"eleTauTree"<<std::endl;
-	decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
-	decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	mass1 = 0.00051100;
-	mass2 = 0;
-	channel = "et";
-	std::cout << "Identified channel et and using kappa = 4" << std::endl;
-	svfitAlgorithm.addLogM_fixed(true, 4);
+	    std::cout<<"eleTauTree"<<std::endl;
+	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
+	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+	    mass1 = 0.00051100;
+	    mass2 = 0;
+	    channel = "et";
+	    std::cout << "Identified channel et and using kappa = 4" << std::endl;
+	    svfitAlgorithm.addLogM_fixed(true, 4);
       } 
-      else if ( std::string(key->GetName()).find("muTauEvent") != std::string::npos ||
-		std::string(key->GetName()).find("mutau_tree") != std::string::npos ) {
-	std::cout << "muTauEvent" << std::endl;
-	decayType1 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
-	decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	mass1 = 0.105658;
-	mass2 = 0;
-	channel = "mt";
-	std::cout << "Identified channel mt and using kappa = 4" << std::endl;
-	svfitAlgorithm.addLogM_fixed(true, 4);
+      else if ( std::string(key->GetName()).find("mt") != std::string::npos ) {
+
+	    std::cout << "muTauEvent" << std::endl;
+	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
+	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+	    mass1 = 0.105658;
+	    mass2 = 0;
+	    channel = "mt";
+	    std::cout << "Identified channel mt and using kappa = 4" << std::endl;
+	    svfitAlgorithm.addLogM_fixed(true, 4);
       } else {
-	std::cout<<"Tree "<< key->GetName() <<" does not match ... Skipping!!"<<std::endl;
-	return;
+	    std::cout<<"Tree "<< key->GetName() <<" does not match ... Skipping!!"<<std::endl;
+	    return;
       }
       
       TTree *t = (TTree*)obj;
@@ -680,10 +678,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       float pfCovMatrix11;
       //float mvamet_ex, // uncorrected mva met px (float)
       //  mvamet_ey, // uncorrected mva met py (float)
-      float  genPx=-999.    , // generator Z/W/Higgs px (float)
-        genPy =-999.   , // generator Z/W/Higgs py (float)
-        visPx =-999.   , // generator visible Z/W/Higgs px (float)
-        visPy =-999.   ; // generator visible Z/W/Higgs py (float)
 
       int njets =-999.   ;  // number of jets (hadronic jet multiplicity) (int)
 
@@ -735,20 +729,15 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("m_2",&m2);
       //t->SetBranchAddress("l1_decayMode",&decayMode);
       if ( channel != "tt" ) t->SetBranchAddress("l2_decayMode",&decayMode2);
-      t->SetBranchAddress("mvacov00",&mvaCovMatrix00);
-      t->SetBranchAddress("mvacov01",&mvaCovMatrix01);
-      t->SetBranchAddress("mvacov10",&mvaCovMatrix10);
-      t->SetBranchAddress("mvacov11",&mvaCovMatrix11);
-      t->SetBranchAddress("mvamet",&mvamet);
-      t->SetBranchAddress("mvametphi",&mvametphi);
+      t->SetBranchAddress("mvacov00",&mvaCovMatrix00);  // branch not stored in et/mt trees
+      t->SetBranchAddress("mvacov01",&mvaCovMatrix01);  // branch not stored in et/mt trees
+      t->SetBranchAddress("mvacov10",&mvaCovMatrix10);  // branch not stored in et/mt trees
+      t->SetBranchAddress("mvacov11",&mvaCovMatrix11);  // branch not stored in et/mt trees
+      t->SetBranchAddress("mvamet",&mvamet);            // branch not stored in et/mt trees
+      t->SetBranchAddress("mvametphi",&mvametphi);      // branch not stored in et/mt trees
       t->SetBranchAddress("njets", &njets);
       t->SetBranchAddress("met",&pfmet);
       t->SetBranchAddress("metphi",&pfmetphi);
-      // Recoil variables below
-      t->SetBranchAddress( "genpX", &genPx);
-      t->SetBranchAddress( "genpY", &genPy);
-      t->SetBranchAddress( "vispX", &visPx);
-      t->SetBranchAddress( "vispY", &visPy);
       // FOR PF MET ANALYSIS
       t->SetBranchAddress("metcov00",&pfCovMatrix00);
       t->SetBranchAddress("metcov01",&pfCovMatrix01);
@@ -756,24 +745,24 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("metcov11",&pfCovMatrix11);
       // Met Unc
       if ( channel ==  "tt" ) {
-	t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnUp",&uncMetPtUp);
-	t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnDown",&uncMetPtDown);
-	t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnUp",&uncMetPhiUp);
-	t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnDown",&uncMetPhiDown);
-	t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnUp",&clusteredMetPtUp);
-	t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnDown",&clusteredMetPtDown);
-	t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnUp",&clusteredMetPhiUp);
-	t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnDown",&clusteredMetPhiDown);
+	    t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnUp",&uncMetPtUp);
+	    t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnDown",&uncMetPtDown);
+	    t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnUp",&uncMetPhiUp);
+	    t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnDown",&uncMetPhiDown);
+	    t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnUp",&clusteredMetPtUp);
+	    t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnDown",&clusteredMetPtDown);
+	    t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnUp",&clusteredMetPhiUp);
+	    t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnDown",&clusteredMetPhiDown);
       } else  {
-	t->SetBranchAddress("met_UESUp", &uncMetPtUp);
-	t->SetBranchAddress("met_UESDown", &uncMetPtDown);
-	t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);
-	t->SetBranchAddress("metphi_UESDown", &uncMetPhiDown);
+	    t->SetBranchAddress("met_UESUp", &uncMetPtUp);
+	    t->SetBranchAddress("met_UESDown", &uncMetPtDown);
+	    t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);
+	    t->SetBranchAddress("metphi_UESDown", &uncMetPhiDown);
 
-	t->SetBranchAddress("met_JESUp", &clusteredMetPtUp);
-	t->SetBranchAddress("met_JESDown", &clusteredMetPtDown);
-	t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
-	t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
+	    t->SetBranchAddress("met_JESUp", &clusteredMetPtUp);
+	    t->SetBranchAddress("met_JESDown", &clusteredMetPtDown);
+	    t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
+	    t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
       }
       
       printf("Found tree -> weighting\n");
@@ -784,157 +773,157 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       int nevents = t->GetEntries();
       if ( parser.integerValue("numEvents") != -1 ) nevents = parser.integerValue("numEvents");
       for(Int_t i=0;i<nevents;++i){
-	t->GetEntry(i);
+	    t->GetEntry(i);
 
-         // Using PF Met or Mva Met?
-         if (metType == 1) { // 1 = Mva Met
-	   TMet.SetPtEtaPhiM(mvamet,0,mvametphi,0);
-	   measuredMETx = mvamet*TMath::Cos(mvametphi);
-	   measuredMETy = mvamet*TMath::Sin(mvametphi);
-	   
-	   covMET[0][0] =  mvaCovMatrix00;
-	   covMET[1][0] =  mvaCovMatrix10;
-	   covMET[0][1] =  mvaCovMatrix01;
-	   covMET[1][1] =  mvaCovMatrix11;
-         } // mva met
-         if (metType == -1) { // -1 = PF Met
-	   TMet.SetPtEtaPhiM(pfmet,0,pfmetphi,0);
-	   measuredMETx = pfmet*TMath::Cos(pfmetphi);
-	   measuredMETy = pfmet*TMath::Sin(pfmetphi);
-	   // Shifted METs
-	   uncMetUpMETx         = uncMetPtUp*TMath::Cos(uncMetPhiUp);
-	   uncMetUpMETy         = uncMetPtUp*TMath::Sin(uncMetPhiUp);
-	   uncMetDownMETx       = uncMetPtDown*TMath::Cos(uncMetPhiDown);
-	   uncMetDownMETy       = uncMetPtDown*TMath::Sin(uncMetPhiDown);
-	   clusteredMetUpMETx   = clusteredMetPtUp*TMath::Cos(clusteredMetPhiUp);
-	   clusteredMetUpMETy   = clusteredMetPtUp*TMath::Sin(clusteredMetPhiUp);
-	   clusteredMetDownMETx = clusteredMetPtDown*TMath::Cos(clusteredMetPhiDown);
-	   clusteredMetDownMETy = clusteredMetPtDown*TMath::Sin(clusteredMetPhiDown);
-	   
-	   covMET[0][0] =  pfCovMatrix00;
-	   covMET[1][0] =  pfCovMatrix10;
-	   covMET[0][1] =  pfCovMatrix01;
-	   covMET[1][1] =  pfCovMatrix11;
-         } // pf met
+        // Using PF Met or Mva Met?
+        if (metType == 1) { // 1 = Mva Met
+          std::cerr << "Only PF Met is currently supported. You're in for a world full of problems if you continue." << std::endl;
+	      TMet.SetPtEtaPhiM(mvamet,0,mvametphi,0);
+	      measuredMETx = mvamet*TMath::Cos(mvametphi);
+	      measuredMETy = mvamet*TMath::Sin(mvametphi);
+	      
+	      covMET[0][0] =  mvaCovMatrix00;
+	      covMET[1][0] =  mvaCovMatrix10;
+	      covMET[0][1] =  mvaCovMatrix01;
+	      covMET[1][1] =  mvaCovMatrix11;
+        } // mva met
+        if (metType == -1) { // -1 = PF Met
+	      TMet.SetPtEtaPhiM(pfmet,0,pfmetphi,0);
+	      measuredMETx = pfmet*TMath::Cos(pfmetphi);
+	      measuredMETy = pfmet*TMath::Sin(pfmetphi);
+	      // Shifted METs
+	      uncMetUpMETx         = uncMetPtUp*TMath::Cos(uncMetPhiUp);
+	      uncMetUpMETy         = uncMetPtUp*TMath::Sin(uncMetPhiUp);
+	      uncMetDownMETx       = uncMetPtDown*TMath::Cos(uncMetPhiDown);
+	      uncMetDownMETy       = uncMetPtDown*TMath::Sin(uncMetPhiDown);
+	      clusteredMetUpMETx   = clusteredMetPtUp*TMath::Cos(clusteredMetPhiUp);
+	      clusteredMetUpMETy   = clusteredMetPtUp*TMath::Sin(clusteredMetPhiUp);
+	      clusteredMetDownMETx = clusteredMetPtDown*TMath::Cos(clusteredMetPhiDown);
+	      clusteredMetDownMETy = clusteredMetPtDown*TMath::Sin(clusteredMetPhiDown);
+	      
+	      covMET[0][0] =  pfCovMatrix00;
+	      covMET[1][0] =  pfCovMatrix10;
+	      covMET[0][1] =  pfCovMatrix01;
+	      covMET[1][1] =  pfCovMatrix11;
+        } // pf met
 	 
-     metcorr_ex = measuredMETx;
-     metcorr_ey = measuredMETy;
-     metcorrUncUp_ex = uncMetUpMETx;
-     metcorrUncUp_ey = uncMetUpMETy;
-     metcorrUncDown_ex = uncMetDownMETx;
-     metcorrUncDown_ey = uncMetDownMETy;
-     metcorrClusteredUp_ex = clusteredMetUpMETx;
-     metcorrClusteredUp_ey = clusteredMetUpMETy;
-     metcorrClusteredDown_ex = clusteredMetDownMETx;
-     metcorrClusteredDown_ey = clusteredMetDownMETy;
+        metcorr_ex = measuredMETx;
+        metcorr_ey = measuredMETy;
+        metcorrUncUp_ex = uncMetUpMETx;
+        metcorrUncUp_ey = uncMetUpMETy;
+        metcorrUncDown_ex = uncMetDownMETx;
+        metcorrUncDown_ey = uncMetDownMETy;
+        metcorrClusteredUp_ex = clusteredMetUpMETx;
+        metcorrClusteredUp_ey = clusteredMetUpMETy;
+        metcorrClusteredDown_ex = clusteredMetDownMETx;
+        metcorrClusteredDown_ey = clusteredMetDownMETy;
+	    
+	    metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
+	    metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
+	    std::cout << " - metcor "<<metcor<<" metcorphi "<<metcorphi<<std::endl;
+	    
+	    // Corrected MET values for saving
+	    // Will be re-corrected with TEC if running tautau channel
+	    metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
+	    metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
+	    
+	    metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
+	    metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
+	    
+	    metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
+	    metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
+	    
+	    metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
+	    metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
 	 
-	 metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
-	 metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
-	 std::cout << " - metcor "<<metcor<<" metcorphi "<<metcorphi<<std::endl;
-	 
-	 // Corrected MET values for saving
-	 // Will be re-corrected with TEC if running tautau channel
-	 metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
-	 metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
-	 
-	 metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
-	 metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
-	 
-	 metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
-	 metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
-	 
-	 metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
-	 metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
-	 
-	 if(channel=="mt"||channel=="et"){
-	   
-	   float shiftTau=1.0;
-	   if (gen_match_2==5 && decayMode2==0) shiftTau=0.982;
-	   if (gen_match_2==5 && decayMode2==1) shiftTau=1.010;
-	   if (gen_match_2==5 && decayMode2==10) shiftTau=1.004;
-	   pt2 = pt2 * shiftTau;
-	   double dx2, dy2;
-	   dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau ) - 1.);
-	   dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau ) - 1.);
-	   metcorr_ex = metcorr_ex + dx2;
-	   metcorr_ey = metcorr_ey + dy2;
-	   
-	   mass2 = m2;
-	   std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons;
-	   measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
-	   
-	   measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2)); 
-	   std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
-	   //modified
-	   runSVFit(measuredTauLeptons, 
-		    metcorr_ex, metcorr_ey, covMET, 0, 
-		    svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
-	   std::cout<<"finished runningSVFit"<<std::endl;
-	   
-	   if(doES) {
-	     
-	     if (gen_match_2<=5){
-	       float ES_UP_scale=1.0; // this value is for jet -> tau fakes
-	       if (gen_match_2<5) ES_UP_scale=1.01; // for gen matched ele/muon
-	       if (gen_match_2==5) ES_UP_scale=tesUP; // for real taus
-	       double pt2_UP;
-	       pt2_UP = pt2 * ES_UP_scale;
-	       double metcorr_ex_UP, metcorr_ey_UP;
-	       double dx2_UP, dy2_UP;
-	       dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
-	       dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
-	       metcorr_ex_UP = metcorr_ex + dx2_UP;
-	       metcorr_ey_UP = metcorr_ey + dy2_UP;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-	       measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
-	       measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-	       
-	       runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
-	     }
-	     else {
-	       svFitMass_UP=svFitMass;
-	       svFitPt_UP=svFitPt;
-	       svFitEta_UP=svFitEta;
-	       svFitPhi_UP=svFitPhi;
-	       svFitMET_UP=svFitMET;
-	       svFitTransverseMass_UP=svFitTransverseMass;
-	       tau1_up = tau1;
-	       tau2_up = tau2;
-	     }
-	     
-	     // Second ES Down, x 0.97
-	     if (gen_match_2<=5){
-	       float ES_DOWN_scale=1.0; // jet
-	       if (gen_match_2==5) ES_DOWN_scale=tesDOWN; // tau
-	       if (gen_match_2<5) ES_DOWN_scale=0.990;  // elec/mu
-	       double pt2_DOWN;
-	       pt2_DOWN = pt2 * ES_DOWN_scale;
-	       double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	       double dx2_DOWN, dy2_DOWN;
-	       dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
-	       dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
-	       metcorr_ex_DOWN = metcorr_ex + dx2_DOWN;
-	       metcorr_ey_DOWN = metcorr_ey + dy2_DOWN;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;          
-	       measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
-	       measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-	       
-	       runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
-	     }
-	     else {
-	       svFitMass_DOWN=svFitMass;
-	       svFitPt_DOWN=svFitPt;
-	       svFitEta_DOWN=svFitEta;
-	       svFitPhi_DOWN=svFitPhi;
-	       svFitMET_DOWN=svFitMET;
-	       svFitTransverseMass_DOWN=svFitTransverseMass;
-	       tau1_down = tau1;
-	       tau2_down = tau2;
-	     }
-	   } // end doES
-	 } // eTau / muTau
+	    if( channel == "mt" || channel == "et" ) {
+	      
+	      float shiftTau=1.0;
+	      if (gen_match_2==5 && decayMode2==0) shiftTau=0.982;
+	      if (gen_match_2==5 && decayMode2==1) shiftTau=1.010;
+	      if (gen_match_2==5 && decayMode2==10) shiftTau=1.004;
+	      pt2 = pt2 * shiftTau;
+	      double dx2, dy2;
+	      dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau ) - 1.);
+	      dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau ) - 1.);
+	      metcorr_ex = metcorr_ex + dx2;
+	      metcorr_ey = metcorr_ey + dy2;
+	      
+	      mass2 = m2;
+	      std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons{
+              classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+              classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2)
+          };
+ 
+	      std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
+	      //modified
+	      runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, 
+	           svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
+	      std::cout<<"finished runningSVFit"<<std::endl;
+	      
+	      if(doES) {
+	        
+	        if (gen_match_2<=5){
+	          float ES_UP_scale=1.0; // this value is for jet -> tau fakes
+	          if (gen_match_2<5) ES_UP_scale=1.01; // for gen matched ele/muon
+	          if (gen_match_2==5) ES_UP_scale=tesUP; // for real taus
+	          double pt2_UP;
+	          pt2_UP = pt2 * ES_UP_scale;
+	          double metcorr_ex_UP, metcorr_ey_UP;
+	          double dx2_UP, dy2_UP;
+	          dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
+	          dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
+	          metcorr_ex_UP = metcorr_ex + dx2_UP;
+	          metcorr_ey_UP = metcorr_ey + dy2_UP;
+	          
+	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+	              classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2)
+              };
+	          
+	          runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+	        } else {
+	          svFitMass_UP=svFitMass;
+	          svFitPt_UP=svFitPt;
+	          svFitEta_UP=svFitEta;
+	          svFitPhi_UP=svFitPhi;
+	          svFitMET_UP=svFitMET;
+	          svFitTransverseMass_UP=svFitTransverseMass;
+	          tau1_up = tau1;
+	          tau2_up = tau2;
+	        }
+	        
+	        // Second ES Down, x 0.97
+	        if (gen_match_2<=5){
+	          float ES_DOWN_scale=1.0; // jet
+	          if (gen_match_2==5) ES_DOWN_scale=tesDOWN; // tau
+	          if (gen_match_2<5) ES_DOWN_scale=0.990;  // elec/mu
+	          double pt2_DOWN;
+	          pt2_DOWN = pt2 * ES_DOWN_scale;
+	          double metcorr_ex_DOWN, metcorr_ey_DOWN;
+	          double dx2_DOWN, dy2_DOWN;
+	          dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
+	          dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
+	          metcorr_ex_DOWN = metcorr_ex + dx2_DOWN;
+	          metcorr_ey_DOWN = metcorr_ey + dy2_DOWN;
+	          
+	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;          
+	          measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
+	          measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+	          
+	          runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+	        } else {
+	          svFitMass_DOWN=svFitMass;
+	          svFitPt_DOWN=svFitPt;
+	          svFitEta_DOWN=svFitEta;
+	          svFitPhi_DOWN=svFitPhi;
+	          svFitMET_DOWN=svFitMET;
+	          svFitTransverseMass_DOWN=svFitTransverseMass;
+	          tau1_down = tau1;
+	          tau2_down = tau2;
+	        }
+	      } // end doES
+	    } // eTau / muTau
 	 
 	 else if(channel=="em"){
 	   // define lepton four vectors

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -60,11 +60,11 @@ int main (int argc, char* argv[])
   parser.parseArguments (argc, argv);
   
   std::cout << "EXTRA COMMANDS:"
-	    << "\n --- numEvents: " << parser.integerValue("numEvents")
-	    << "\n --- doES: " << parser.doubleValue("doES")
-	    << "\n --- isWJets: " << parser.doubleValue("isWJets")
-	    << "\n --- metType: " << parser.doubleValue("metType")
-	    << "\n --- tesSize: " << parser.doubleValue("tesSize") << std::endl;
+        << "\n --- numEvents: " << parser.integerValue("numEvents")
+        << "\n --- doES: " << parser.doubleValue("doES")
+        << "\n --- isWJets: " << parser.doubleValue("isWJets")
+        << "\n --- metType: " << parser.doubleValue("metType")
+        << "\n --- tesSize: " << parser.doubleValue("tesSize") << std::endl;
   
   // Make sure a proper Met Type is chosen
   assert (parser.doubleValue("metType") == 1.0 || parser.doubleValue("metType") == -1.0);
@@ -148,55 +148,55 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       // check  if this tree was already processed
       std::vector<TString>::const_iterator it = find(processedNames.begin(), processedNames.end(), key->GetName());
       if ( it != processedNames.end() ) {
-	    std::cout << "This tree was already processed, skipping..." <<  std::endl;
-	    continue;
+        std::cout << "This tree was already processed, skipping..." <<  std::endl;
+        continue;
       }
       std::cout << "This is the tree! Start processing" << std::endl;
       processedNames.push_back(key->GetName());
       
       // Identify the process
       if ( std::string(key->GetName()).find("tt") != std::string::npos )  {
-	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	    mass1 = 0.13957;
-	    mass2 = 0.13957;
-	    channel = "tt";
-	    std::cout << "Identified channel tt and using kappa = 5" << std::endl;
-	    svfitAlgorithm.addLogM_fixed(true, 5);
+        decayType1 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+        decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+        mass1 = 0.13957;
+        mass2 = 0.13957;
+        channel = "tt";
+        std::cout << "Identified channel tt and using kappa = 5" << std::endl;
+        svfitAlgorithm.addLogM_fixed(true, 5);
       } 
       else if ( std::string(key->GetName()).find("em") != std::string::npos )  {
-	    std::cout<< "EMu sample" <<std::endl;
-	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
-	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
-	    mass1 = 0.00051100;
-	    mass2 = 0.105658;
-	    channel = "em";
-	    std::cout << "Identified channel em and using kappa = 3" << std::endl;
-	    svfitAlgorithm.addLogM_fixed(true, 3);
+        std::cout<< "EMu sample" <<std::endl;
+        decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
+        decayType2 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
+        mass1 = 0.00051100;
+        mass2 = 0.105658;
+        channel = "em";
+        std::cout << "Identified channel em and using kappa = 3" << std::endl;
+        svfitAlgorithm.addLogM_fixed(true, 3);
       }
       else if ( std::string(key->GetName()).find("et") != std::string::npos ) {
-	    std::cout<<"eleTauTree"<<std::endl;
-	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
-	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	    mass1 = 0.00051100;
-	    mass2 = 0;
-	    channel = "et";
-	    std::cout << "Identified channel et and using kappa = 4" << std::endl;
-	    svfitAlgorithm.addLogM_fixed(true, 4);
+        std::cout<<"eleTauTree"<<std::endl;
+        decayType1 = classic_svFit::MeasuredTauLepton::kTauToElecDecay;
+        decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+        mass1 = 0.00051100;
+        mass2 = 0;
+        channel = "et";
+        std::cout << "Identified channel et and using kappa = 4" << std::endl;
+        svfitAlgorithm.addLogM_fixed(true, 4);
       } 
       else if ( std::string(key->GetName()).find("mt") != std::string::npos ) {
 
-	    std::cout << "muTauEvent" << std::endl;
-	    decayType1 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
-	    decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
-	    mass1 = 0.105658;
-	    mass2 = 0;
-	    channel = "mt";
-	    std::cout << "Identified channel mt and using kappa = 4" << std::endl;
-	    svfitAlgorithm.addLogM_fixed(true, 4);
+        std::cout << "muTauEvent" << std::endl;
+        decayType1 = classic_svFit::MeasuredTauLepton::kTauToMuDecay;
+        decayType2 = classic_svFit::MeasuredTauLepton::kTauToHadDecay;
+        mass1 = 0.105658;
+        mass2 = 0;
+        channel = "mt";
+        std::cout << "Identified channel mt and using kappa = 4" << std::endl;
+        svfitAlgorithm.addLogM_fixed(true, 4);
       } else {
-	    std::cout<<"Tree "<< key->GetName() <<" does not match ... Skipping!!"<<std::endl;
-	    return;
+        std::cout<<"Tree "<< key->GetName() <<" does not match ... Skipping!!"<<std::endl;
+        return;
       }
       
       TTree *t = (TTree*)obj;
@@ -718,8 +718,8 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("lumi",&lumi);
       t->SetBranchAddress("gen_match_1",&gen_match_1);
       t->SetBranchAddress("gen_match_2",&gen_match_2);
-	  if ( channel == "tt" ) t->SetBranchAddress("t1_decayMode", &decayMode);
-	  if ( channel == "tt" ) t->SetBranchAddress("t2_decayMode", &decayMode2);
+      if ( channel == "tt" ) t->SetBranchAddress("t1_decayMode", &decayMode);
+      if ( channel == "tt" ) t->SetBranchAddress("t2_decayMode", &decayMode2);
       t->SetBranchAddress("pt_1",&pt1,&pt1branch);
       t->SetBranchAddress("eta_1",&eta1);
       t->SetBranchAddress("phi_1",&phi1);
@@ -745,24 +745,24 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       t->SetBranchAddress("metcov11",&pfCovMatrix11);
       // Met Unc
       if ( channel ==  "tt" ) {
-	    t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnUp",&uncMetPtUp);
-	    t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnDown",&uncMetPtDown);
-	    t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnUp",&uncMetPhiUp);
-	    t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnDown",&uncMetPhiDown);
-	    t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnUp",&clusteredMetPtUp);
-	    t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnDown",&clusteredMetPtDown);
-	    t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnUp",&clusteredMetPhiUp);
-	    t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnDown",&clusteredMetPhiDown);
+        t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnUp",&uncMetPtUp);
+        t->SetBranchAddress("type1_pfMet_shiftedPt_UnclusteredEnDown",&uncMetPtDown);
+        t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnUp",&uncMetPhiUp);
+        t->SetBranchAddress("type1_pfMet_shiftedPhi_UnclusteredEnDown",&uncMetPhiDown);
+        t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnUp",&clusteredMetPtUp);
+        t->SetBranchAddress("type1_pfMet_shiftedPt_JetEnDown",&clusteredMetPtDown);
+        t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnUp",&clusteredMetPhiUp);
+        t->SetBranchAddress("type1_pfMet_shiftedPhi_JetEnDown",&clusteredMetPhiDown);
       } else  {
-	    t->SetBranchAddress("met_UESUp", &uncMetPtUp);
-	    t->SetBranchAddress("met_UESDown", &uncMetPtDown);
-	    t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);
-	    t->SetBranchAddress("metphi_UESDown", &uncMetPhiDown);
+        t->SetBranchAddress("met_UESUp", &uncMetPtUp);
+        t->SetBranchAddress("met_UESDown", &uncMetPtDown);
+        t->SetBranchAddress("metphi_UESUp", &uncMetPhiUp);
+        t->SetBranchAddress("metphi_UESDown", &uncMetPhiDown);
 
-	    t->SetBranchAddress("met_JESUp", &clusteredMetPtUp);
-	    t->SetBranchAddress("met_JESDown", &clusteredMetPtDown);
-	    t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
-	    t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
+        t->SetBranchAddress("met_JESUp", &clusteredMetPtUp);
+        t->SetBranchAddress("met_JESDown", &clusteredMetPtDown);
+        t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
+        t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
       }
       
       printf("Found tree -> weighting\n");
@@ -773,40 +773,40 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       int nevents = t->GetEntries();
       if ( parser.integerValue("numEvents") != -1 ) nevents = parser.integerValue("numEvents");
       for(Int_t i=0;i<nevents;++i){
-	    t->GetEntry(i);
+        t->GetEntry(i);
 
         // Using PF Met or Mva Met?
         if (metType == 1) { // 1 = Mva Met
           std::cerr << "Only PF Met is currently supported. You're in for a world full of problems if you continue." << std::endl;
-	      TMet.SetPtEtaPhiM(mvamet,0,mvametphi,0);
-	      measuredMETx = mvamet*TMath::Cos(mvametphi);
-	      measuredMETy = mvamet*TMath::Sin(mvametphi);
-	      
-	      covMET[0][0] =  mvaCovMatrix00;
-	      covMET[1][0] =  mvaCovMatrix10;
-	      covMET[0][1] =  mvaCovMatrix01;
-	      covMET[1][1] =  mvaCovMatrix11;
+          TMet.SetPtEtaPhiM(mvamet,0,mvametphi,0);
+          measuredMETx = mvamet*TMath::Cos(mvametphi);
+          measuredMETy = mvamet*TMath::Sin(mvametphi);
+          
+          covMET[0][0] =  mvaCovMatrix00;
+          covMET[1][0] =  mvaCovMatrix10;
+          covMET[0][1] =  mvaCovMatrix01;
+          covMET[1][1] =  mvaCovMatrix11;
         } // mva met
         if (metType == -1) { // -1 = PF Met
-	      TMet.SetPtEtaPhiM(pfmet,0,pfmetphi,0);
-	      measuredMETx = pfmet*TMath::Cos(pfmetphi);
-	      measuredMETy = pfmet*TMath::Sin(pfmetphi);
-	      // Shifted METs
-	      uncMetUpMETx         = uncMetPtUp*TMath::Cos(uncMetPhiUp);
-	      uncMetUpMETy         = uncMetPtUp*TMath::Sin(uncMetPhiUp);
-	      uncMetDownMETx       = uncMetPtDown*TMath::Cos(uncMetPhiDown);
-	      uncMetDownMETy       = uncMetPtDown*TMath::Sin(uncMetPhiDown);
-	      clusteredMetUpMETx   = clusteredMetPtUp*TMath::Cos(clusteredMetPhiUp);
-	      clusteredMetUpMETy   = clusteredMetPtUp*TMath::Sin(clusteredMetPhiUp);
-	      clusteredMetDownMETx = clusteredMetPtDown*TMath::Cos(clusteredMetPhiDown);
-	      clusteredMetDownMETy = clusteredMetPtDown*TMath::Sin(clusteredMetPhiDown);
-	      
-	      covMET[0][0] =  pfCovMatrix00;
-	      covMET[1][0] =  pfCovMatrix10;
-	      covMET[0][1] =  pfCovMatrix01;
-	      covMET[1][1] =  pfCovMatrix11;
+          TMet.SetPtEtaPhiM(pfmet,0,pfmetphi,0);
+          measuredMETx = pfmet*TMath::Cos(pfmetphi);
+          measuredMETy = pfmet*TMath::Sin(pfmetphi);
+          // Shifted METs
+          uncMetUpMETx         = uncMetPtUp*TMath::Cos(uncMetPhiUp);
+          uncMetUpMETy         = uncMetPtUp*TMath::Sin(uncMetPhiUp);
+          uncMetDownMETx       = uncMetPtDown*TMath::Cos(uncMetPhiDown);
+          uncMetDownMETy       = uncMetPtDown*TMath::Sin(uncMetPhiDown);
+          clusteredMetUpMETx   = clusteredMetPtUp*TMath::Cos(clusteredMetPhiUp);
+          clusteredMetUpMETy   = clusteredMetPtUp*TMath::Sin(clusteredMetPhiUp);
+          clusteredMetDownMETx = clusteredMetPtDown*TMath::Cos(clusteredMetPhiDown);
+          clusteredMetDownMETy = clusteredMetPtDown*TMath::Sin(clusteredMetPhiDown);
+          
+          covMET[0][0] =  pfCovMatrix00;
+          covMET[1][0] =  pfCovMatrix10;
+          covMET[0][1] =  pfCovMatrix01;
+          covMET[1][1] =  pfCovMatrix11;
         } // pf met
-	 
+     
         metcorr_ex = measuredMETx;
         metcorr_ey = measuredMETy;
         metcorrUncUp_ex = uncMetUpMETx;
@@ -817,53 +817,53 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
         metcorrClusteredUp_ey = clusteredMetUpMETy;
         metcorrClusteredDown_ex = clusteredMetDownMETx;
         metcorrClusteredDown_ey = clusteredMetDownMETy;
-	    
-	    metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
-	    metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
-	    std::cout << " - metcor "<<metcor<<" metcorphi "<<metcorphi<<std::endl;
-	    
-	    // Corrected MET values for saving
-	    // Will be re-corrected with TEC if running tautau channel
-	    metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
-	    metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
-	    
-	    metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
-	    metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
-	    
-	    metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
-	    metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
-	    
-	    metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
-	    metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
-	 
-	    if( channel == "mt" || channel == "et" ) {
-	      
-	      float shiftTau=1.0;
-	      if (gen_match_2==5 && decayMode2==0) shiftTau=0.982;
-	      if (gen_match_2==5 && decayMode2==1) shiftTau=1.010;
-	      if (gen_match_2==5 && decayMode2==10) shiftTau=1.004;
-	      pt2 = pt2 * shiftTau;
-	      double dx2, dy2;
-	      dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau ) - 1.);
-	      dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau ) - 1.);
-	      metcorr_ex = metcorr_ex + dx2;
-	      metcorr_ey = metcorr_ey + dy2;
-	      
-	      mass2 = m2;
-	      std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons{
+        
+        metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
+        metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
+        std::cout << " - metcor "<<metcor<<" metcorphi "<<metcorphi<<std::endl;
+        
+        // Corrected MET values for saving
+        // Will be re-corrected with TEC if running tautau channel
+        metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
+        metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
+        
+        metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
+        metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
+        
+        metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
+        metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
+        
+        metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
+        metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
+     
+        if( channel == "mt" || channel == "et" ) {
+          
+          float shiftTau=1.0;
+          if (gen_match_2==5 && decayMode2==0) shiftTau=0.982;
+          if (gen_match_2==5 && decayMode2==1) shiftTau=1.010;
+          if (gen_match_2==5 && decayMode2==10) shiftTau=1.004;
+          pt2 = pt2 * shiftTau;
+          double dx2, dy2;
+          dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau ) - 1.);
+          dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau ) - 1.);
+          metcorr_ex = metcorr_ex + dx2;
+          metcorr_ey = metcorr_ey + dy2;
+          
+          mass2 = m2;
+          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons{
               classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
               classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2)
           };
  
-	      std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
-	      //modified
-	      runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, 
-	           svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
-	      std::cout<<"finished runningSVFit"<<std::endl;
+          std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
+          //modified
+          runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, 
+               svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
+          std::cout<<"finished runningSVFit"<<std::endl;
 
           // TODO: MET Systematics 
-	      
-	      if(doES) {
+          
+          if(doES) {
             
             // corrections only need to be done once
             float ES_UP( tesUP ), ES_DOWN( tesDOWN ); // Energy scale
@@ -929,9 +929,9 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM1 shifted up
             if (gen_match_2 == 5 && decayMode2 == 1) {
               std::cout << "DM1 shift up" << std::endl;
-	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
                   classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-	              classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
+                  classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
               };
 
               runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, 
@@ -950,9 +950,9 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM10 shifted up
             if (gen_match_2 == 5 && decayMode2 == 10) {
               std::cout << "DM10 shift up" << std::endl;
-	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
                   classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-	              classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
+                  classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
               };
 
               runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, 
@@ -1008,9 +1008,9 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM1 shifted down
             if (gen_match_2 == 5 && decayMode2 == 1) {
               std::cout << "DM1 shift down" << std::endl;
-	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
+              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
                   classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-	              classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
+                  classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
               };
 
               runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, 
@@ -1029,9 +1029,9 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM10 shifted down
             if (gen_match_2 == 5 && decayMode2 == 10) {
               std::cout << "DM10 shift down" << std::endl;
-	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
+              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
                   classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-	              classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
+                  classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
               };
 
               runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, 
@@ -1047,831 +1047,831 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
               tau2_DM10_down = tau2;
             }
 
-	        if (gen_match_2<=5){
-	          float ES_UP_scale=1.0; // this value is for jet -> tau fakes
-	          if (gen_match_2<5) ES_UP_scale=1.01; // for gen matched ele/muon
-	          if (gen_match_2==5) ES_UP_scale=tesUP; // for real taus
-	          double pt2_UP;
-	          pt2_UP = pt2 * ES_UP_scale;
-	          double metcorr_ex_UP, metcorr_ey_UP;
-	          double dx2_UP, dy2_UP;
-	          dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
-	          dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
-	          metcorr_ex_UP = metcorr_ex + dx2_UP;
-	          metcorr_ey_UP = metcorr_ey + dy2_UP;
-	          
-	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+            if (gen_match_2<=5){
+              float ES_UP_scale=1.0; // this value is for jet -> tau fakes
+              if (gen_match_2<5) ES_UP_scale=1.01; // for gen matched ele/muon
+              if (gen_match_2==5) ES_UP_scale=tesUP; // for real taus
+              double pt2_UP;
+              pt2_UP = pt2 * ES_UP_scale;
+              double metcorr_ex_UP, metcorr_ey_UP;
+              double dx2_UP, dy2_UP;
+              dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
+              dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
+              metcorr_ex_UP = metcorr_ex + dx2_UP;
+              metcorr_ey_UP = metcorr_ey + dy2_UP;
+              
+              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
                   classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-	              classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2)
+                  classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2)
               };
-	          
-	          runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
-	        } else {
-	          svFitMass_UP=svFitMass;
-	          svFitPt_UP=svFitPt;
-	          svFitEta_UP=svFitEta;
-	          svFitPhi_UP=svFitPhi;
-	          svFitMET_UP=svFitMET;
-	          svFitTransverseMass_UP=svFitTransverseMass;
-	          tau1_up = tau1;
-	          tau2_up = tau2;
-	        }
-	        
-	        // Second ES Down, x 0.97
-	        if (gen_match_2<=5){
-	          float ES_DOWN_scale=1.0; // jet
-	          if (gen_match_2==5) ES_DOWN_scale=tesDOWN; // tau
-	          if (gen_match_2<5) ES_DOWN_scale=0.990;  // elec/mu
-	          double pt2_DOWN;
-	          pt2_DOWN = pt2 * ES_DOWN_scale;
-	          double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	          double dx2_DOWN, dy2_DOWN;
-	          dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
-	          dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
-	          metcorr_ex_DOWN = metcorr_ex + dx2_DOWN;
-	          metcorr_ey_DOWN = metcorr_ey + dy2_DOWN;
-	          
-	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;          
-	          measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
-	          measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-	          
-	          runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
-	        } else {
-	          svFitMass_DOWN=svFitMass;
-	          svFitPt_DOWN=svFitPt;
-	          svFitEta_DOWN=svFitEta;
-	          svFitPhi_DOWN=svFitPhi;
-	          svFitMET_DOWN=svFitMET;
-	          svFitTransverseMass_DOWN=svFitTransverseMass;
-	          tau1_down = tau1;
-	          tau2_down = tau2;
-	        }
-	      } // end doES
-	    } // eTau / muTau
-	 
-	 else if(channel=="em"){
-	   // define lepton four vectors
-	   std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons;
-	   measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
-	   measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2, mass2));
-	   
-	   std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
-	   runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
-	   std::cout<<"finished running non-EES SVFit in EMu"<<std::endl;
-	   if(doES) {
-	     
-	     // Only shift Electrons
-	     // 1% shift in barrel and 2.5% shift in endcap
-	     // applied to electrons in emu channel
-	     float etaBarrelEndcap  = 1.479;
-	     float ES_UP_scale;
-	     if (abs(eta1) < etaBarrelEndcap) ES_UP_scale = 1.01;
-	     else ES_UP_scale = 1.025;
-	     double pt1_UP = pt1 * ES_UP_scale;
-	     std::cout << "E eta: " << eta1 << " ees SF: " << ES_UP_scale << std::endl;
-	     double metcorr_ex_UP, metcorr_ey_UP;
-	     double dx1_UP, dy1_UP;
-	     dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale ) - 1.);
-	     dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale ) - 1.);
-	     metcorr_ex_UP = metcorr_ex + dx1_UP;
-	     metcorr_ey_UP = metcorr_ey + dy1_UP;
-	     std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_UP <<std::endl;
-	     std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_UP <<std::endl;
-	     std::cout << "pt1 " << pt1 << "  pt1_up " << pt1_UP <<std::endl;
-	     std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_UP << std::endl;
-	     std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_UP << std::endl;
-	     
-	     std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-	     measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1));
-	     measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2, mass2));
-	     
-	     std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1_UP << " mass1 " << mass1 << " pt2: "<< pt2 << " mass2: "<< mass2 <<std::endl;        
-	     runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
-	     std::cout<<"finished runningSVFit in EMu EES Up"<<std::endl;
-	     
-	     
-	     // EES Down
-	     float ES_DOWN_scale;
-	     if (abs(eta1) < etaBarrelEndcap) ES_DOWN_scale = 0.99;
-	     else ES_DOWN_scale = 0.975;
-	     std::cout << "E eta: " << eta1 << " ees SF: " << ES_DOWN_scale << std::endl;
-	     double pt1_DOWN;
-	     pt1_DOWN = pt1 * ES_DOWN_scale;
-	     double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	     double dx1_DOWN, dy1_DOWN;
-	     dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale ) - 1.);
-	     dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale ) - 1.);
-	     metcorr_ex_DOWN = metcorr_ex + dx1_DOWN;
-	     metcorr_ey_DOWN = metcorr_ey + dy1_DOWN;
-	     std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_DOWN <<std::endl;
-	     std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_DOWN <<std::endl;
-	     std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_DOWN << std::endl;
-	     std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_DOWN << std::endl;
-	     
-	     std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
-	     measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1));
-	     measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2));
-	     
-	     runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
-	     
-	     
-	   } // end doES
-	 } // eMu
-	 
-	 
-	 
-	 else if(channel=="tt"){
-	   
-	   float shiftTau1=1.0;
-	   float shiftTau2=1.0;
-	   if (gen_match_1==5 && decayMode==0) shiftTau1=0.982;
-	   if (gen_match_1==5 && decayMode==1) shiftTau1=1.010;
-	   if (gen_match_1==5 && decayMode==10) shiftTau1=1.004;
-	   if (gen_match_2==5 && decayMode2==0) shiftTau2=0.982;
-	   if (gen_match_2==5 && decayMode2==1) shiftTau2=1.010;
-	   if (gen_match_2==5 && decayMode2==10) shiftTau2=1.004;
-	   pt1 = pt1 * shiftTau1;
-	   pt2 = pt2 * shiftTau2;
-	   double dx1, dy1;
-	   double dx2, dy2;
-	   dx1 = pt1 * TMath::Cos( phi1 ) * (( 1. / shiftTau1 ) - 1.);
-	   dy1 = pt1 * TMath::Sin( phi1 ) * (( 1. / shiftTau1 ) - 1.);
-	   dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau2 ) - 1.);
-	   dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau2 ) - 1.);
-	   metcorr_ex = metcorr_ex + dx1;
-	   metcorr_ey = metcorr_ey + dy1;
-	   metcorr_ex = metcorr_ex + dx2;
-	   metcorr_ey = metcorr_ey + dy2;
-	   
-	   // define lepton four vectors
-	   std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons;
-	   // Add Tau of higest Pt first
-	   if (pt1 > pt2) {
-	     measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1, decayMode));
-	     
-	     measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2));
-	   }
-	   else {
-	     measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2));
-	     
-	     measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1, decayMode));
-	   }
-	   
-	   std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
-	   runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
-	   std::cout<<"finished running non-TES SVFit in TT"<<std::endl;
-	   
-	   
-	   //*****************************************************
-	   // MET SYSTEMATICS
-	   // Taus Pt have been corrected (TEC)
-	   // Still need TEC propagated to shifted METs
-	   //*****************************************************
-	   
-	   std::cout << "MET Unclustered Energy Up   ---  ";
-	   metcorrUncUp_ex = metcorrUncUp_ex + dx1 + dx2;
-	   metcorrUncUp_ey = metcorrUncUp_ey + dy1 + dy2;
-	   runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_UP, svFitPt_UncMet_UP, svFitEta_UncMet_UP, svFitPhi_UncMet_UP, svFitMET_UncMet_UP, svFitTransverseMass_UncMet_UP, tau1_UncMet_up, tau2_UncMet_up);
-	   std::cout << "MET Unclustered Energy Down ---  ";
-	   metcorrUncDown_ex = metcorrUncDown_ex + dx1 + dx2;
-	   metcorrUncDown_ey = metcorrUncDown_ey + dy1 + dy2;
-	   runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_DOWN, svFitPt_UncMet_DOWN, svFitEta_UncMet_DOWN, svFitPhi_UncMet_DOWN, svFitMET_UncMet_DOWN, svFitTransverseMass_UncMet_DOWN, tau1_UncMet_down, tau2_UncMet_down);
-	   std::cout << "MET Clustered Energy Up     ---  ";
-	   metcorrClusteredUp_ex = metcorrClusteredUp_ex + dx1 + dx2;
-	   metcorrClusteredUp_ey = metcorrClusteredUp_ey + dy1 + dy2;
-	   runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_UP, svFitPt_ClusteredMet_UP, svFitEta_ClusteredMet_UP, svFitPhi_ClusteredMet_UP, svFitMET_ClusteredMet_UP, svFitTransverseMass_ClusteredMet_UP, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
-	   std::cout << "MET Clustered Energy Down   ---  ";
-	   metcorrClusteredDown_ex = metcorrClusteredDown_ex + dx1 + dx2;
-	   metcorrClusteredDown_ey = metcorrClusteredDown_ey + dy1 + dy2;
-	   runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_DOWN, svFitPt_ClusteredMet_DOWN, svFitEta_ClusteredMet_DOWN, svFitPhi_ClusteredMet_DOWN, svFitMET_ClusteredMet_DOWN, svFitTransverseMass_ClusteredMet_DOWN, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
-	   std::cout<< "Shifted MET Summary:\nmetcorr_ex " << metcorr_ex << "\n --- metcorrUncUp_ex " << metcorrUncUp_ex << " metcorrUncDown_ex " << metcorrUncDown_ex
-		    << " metcorrClusteredUp_ex " << metcorrClusteredUp_ex << " metcorrClusteredDown_ex " << metcorrClusteredDown_ex << std::endl;
-	   std::cout<< "metcorr_ey " << metcorr_ey << "\n --- metcorrUncUp_ey " << metcorrUncUp_ey << " metcorrUncDown_ey " << metcorrUncDown_ey
-		    << " metcorrClusteredUp_ey " << metcorrClusteredUp_ey << " metcorrClusteredDown_ey " << metcorrClusteredDown_ey << std::endl;
-	   
-	   
-	   // Corrected MET values for saving
-	   metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
-	   metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
-	   metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
-	   metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
-	   metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
-	   metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
-	   metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
-	   metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
-	   metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
-	   metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
-	   
-	   if(doES) {
-	     
-	     //***************************************************************************
-	     //********************* Two taus shifted up *********************************
-	     //***************************************************************************
-	     
-	     if (gen_match_2==5 or gen_match_1==5){
-	       std::cout << "Two UP    ---  ";
-	       float ES_UP_scale1 = 1.0;
-	       float ES_UP_scale2 = 1.0;
-	       if(gen_match_1==5) ES_UP_scale1 = tesUP;
-	       if(gen_match_2==5) ES_UP_scale2 = tesUP;
-	       std::cout << "TES values: gen1: " << gen_match_1 << "   dm_1: " << decayMode;
-	       std::cout << "   tes1: " << ES_UP_scale1;
-	       std::cout << "   gen2: " << gen_match_2 << "   dm_2: " << decayMode2;
-	       std::cout << "   tes2: " << ES_UP_scale2 << std::endl;
-	       double pt1_UP, pt2_UP;
-	       pt1_UP = pt1 * ES_UP_scale1;
-	       pt2_UP = pt2 * ES_UP_scale2;
-	       double metcorr_ex_UP, metcorr_ey_UP;
-	       double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-	       dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-	       metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-	       
-	       // Add Tau of higest Pt first
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-		 
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-		 
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
-	     }
-	     else {
-	       svFitMass_UP=svFitMass;
-	       svFitPt_UP=svFitPt;
-	       svFitEta_UP=svFitEta;
-	       svFitPhi_UP=svFitPhi;
-	       svFitMET_UP=svFitMET;
-	       svFitTransverseMass_UP=svFitTransverseMass;
-	       tau1_up = tau1;
-	       tau2_up = tau2;
-	     }
-	     
-	     //***************************************************************************
-	     //********************** Tau DM0 shifted up *********************************
-	     //***************************************************************************
-	     
-	     if ((gen_match_2==5 && decayMode2==0) or (gen_match_1==5 && decayMode==0)){
-	       std::cout << "DM0 UP    ---  ";
-	       float ES_UP_scale1 = 1.0;
-	       float ES_UP_scale2 = 1.0;
-	       if(gen_match_1==5 && decayMode==0) ES_UP_scale1 = tesUP;
-	       if(gen_match_2==5 && decayMode2==0) ES_UP_scale2 = tesUP;
-	       double pt1_UP, pt2_UP;
-	       pt1_UP = pt1 * ES_UP_scale1;
-	       pt2_UP = pt2 * ES_UP_scale2;
-	       double metcorr_ex_UP, metcorr_ey_UP;
-	       double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-	       dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-	       metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-	       // Add Tau of higest Pt first
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM0_UP, svFitPt_DM0_UP, svFitEta_DM0_UP, svFitPhi_DM0_UP, svFitMET_DM0_UP, svFitTransverseMass_DM0_UP, tau1_DM0_up, tau2_DM0_down);
-	     }
-	     else {
-	       svFitMass_DM0_UP=svFitMass;
-	       svFitPt_DM0_UP=svFitPt;
-	       svFitEta_DM0_UP=svFitEta;
-	       svFitPhi_DM0_UP=svFitPhi;
-	       svFitMET_DM0_UP=svFitMET;
-	       svFitTransverseMass_DM0_UP=svFitTransverseMass;
-	       tau1_DM0_up = tau1;
-	       tau2_DM0_down = tau2;
-	     }
-	     
-	     //***************************************************************************
-	     //********************** Tau DM1 shifted up *********************************
-	     //***************************************************************************
-	     
-	     if ((decayMode==1 && gen_match_1==5) or (decayMode2==1 && gen_match_2==5)){
-	       std::cout << "DM1 UP    ---  ";
-	       float ES_UP_scale1 = 1.0;
-	       float ES_UP_scale2 = 1.0;
-	       if (decayMode==1 && gen_match_1==5) ES_UP_scale1 = tesUP;
-	       if (decayMode2==1 && gen_match_2==5) ES_UP_scale2 = tesUP;
-	       double pt1_UP, pt2_UP;
-	       pt1_UP = pt1 * ES_UP_scale1;
-	       pt2_UP = pt2 * ES_UP_scale2;
-	       double metcorr_ex_UP, metcorr_ey_UP;
-	       double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-	       dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-	       metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-	       // Add Tau of higest Pt first
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, svFitEta_DM1_UP, svFitPhi_DM1_UP, svFitMET_DM1_UP, svFitTransverseMass_DM1_UP, tau1_DM1_up, tau2_DM1_up);
-	     }
-	     else {
-	       svFitMass_DM1_UP=svFitMass;
-	       svFitPt_DM1_UP=svFitPt;
-	       svFitEta_DM1_UP=svFitEta;
-	       svFitPhi_DM1_UP=svFitPhi;
-	       svFitMET_DM1_UP=svFitMET;
-	       svFitTransverseMass_DM1_UP=svFitTransverseMass;
-	       tau1_DM1_up = tau1;
-	       tau2_DM1_up = tau2;
-	     }
-	     
-	     //***************************************************************************
-	     //********************* Tau DM10 shifted up *********************************
-	     //***************************************************************************
-	     
-	     if ((decayMode2==10 && gen_match_2==5) or (decayMode==10 && gen_match_1==5)){
-	       std::cout << "DM10 UP    ---  ";
-	       float ES_UP_scale1 = 1.0;
-	       float ES_UP_scale2 = 1.0;
-	       if(decayMode==10 && gen_match_1==5) ES_UP_scale1 = tesUP;
-	       if(decayMode2==10 && gen_match_2==5) ES_UP_scale2 = tesUP;
-	       double pt1_UP, pt2_UP;
-	       pt1_UP = pt1 * ES_UP_scale1;
-	       pt2_UP = pt2 * ES_UP_scale2;
-	       double metcorr_ex_UP, metcorr_ey_UP;
-	       double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
-	       dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
-	       dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
-	       metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
-	       metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
-	       
-	       // Add Tau of higest Pt first
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
-		 measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, svFitEta_DM10_UP, svFitPhi_DM10_UP, svFitMET_DM10_UP, svFitTransverseMass_DM10_UP, tau1_DM10_up, tau2_DM10_up);
-	     }
-	     else {
-	       svFitMass_DM10_UP=svFitMass;
-	       svFitPt_DM10_UP=svFitPt;
-	       svFitEta_DM10_UP=svFitEta;
-	       svFitPhi_DM10_UP=svFitPhi;
-	       svFitMET_DM10_UP=svFitMET;
-	       svFitTransverseMass_DM10_UP=svFitTransverseMass;
-	       tau1_DM10_up = tau1;
-	       tau2_DM10_up = tau2;
-	     }
-	     
-	     //*****************************************************
-	     //************* Two taus shifted down *****************
-	     //*****************************************************
-	     
-	     if (gen_match_1==5 or gen_match_2==5){
-	       std::cout << "Two DOWN  ---  ";
-	       float ES_DOWN_scale1 = 1.0;
-	       float ES_DOWN_scale2 = 1.0;
-	       if (gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-	       if (gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-	       double pt1_DOWN, pt2_DOWN;
-	       pt1_DOWN = pt1 * ES_DOWN_scale1;
-	       pt2_DOWN = pt2 * ES_DOWN_scale2;
-	       double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	       double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-	       dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-	       metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
-	       
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
-	     }
-	     else {
-	       svFitMass_DOWN=svFitMass;
-	       svFitPt_DOWN=svFitPt;
-	       svFitEta_DOWN=svFitEta;
-	       svFitPhi_DOWN=svFitPhi;
-	       svFitMET_DOWN=svFitMET;
-	       svFitTransverseMass_DOWN=svFitTransverseMass;
-	       tau1_down = tau1;
-	       tau2_down = tau2;
-	     }
-	     
-	     //*****************************************************
-	     //************* Tau DM0 shifted down  *****************
-	     //*****************************************************
-	     
-	     if ((decayMode==0 && gen_match_1==5) or (decayMode2==0 && gen_match_2==5)){
-	       std::cout << "DM0 DOWN  ---  ";
-	       float ES_DOWN_scale1 = 1.0;
-	       float ES_DOWN_scale2 = 1.0;
-	       if (decayMode==0 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-	       if (decayMode2==0 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-	       double pt1_DOWN, pt2_DOWN;
-	       pt1_DOWN = pt1 * ES_DOWN_scale1;
-	       pt2_DOWN = pt2 * ES_DOWN_scale2;
-	       double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	       double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-	       dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-	       metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM0_DOWN, svFitPt_DM0_DOWN, svFitEta_DM0_DOWN, svFitPhi_DM0_DOWN, svFitMET_DM0_DOWN, svFitTransverseMass_DM0_DOWN, tau1_DM0_down, tau2_DM0_down);
-	     }
-	     else {
-	       svFitMass_DM0_DOWN=svFitMass;
-	       svFitPt_DM0_DOWN=svFitPt;
-	       svFitEta_DM0_DOWN=svFitEta;
-	       svFitPhi_DM0_DOWN=svFitPhi;
-	       svFitMET_DM0_DOWN=svFitMET;
-	       svFitTransverseMass_DM0_DOWN=svFitTransverseMass;
-	       tau1_DM0_down = tau1;
-	       tau2_DM0_down = tau2;
-	     }
-	     
-	     //*****************************************************
-	     //************** Tau DM1 shifted down *****************
-	     //*****************************************************
-	     
-	     if ((decayMode==1 && gen_match_1==5) or (decayMode2==1 && gen_match_2==5)){
-	       std::cout << "DM1 DOWN  ---  ";
-	       float ES_DOWN_scale1 = 1.0;
-	       float ES_DOWN_scale2 = 1.0;
-	       if (decayMode==1 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-	       if (decayMode2==1 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-	       double pt1_DOWN, pt2_DOWN;
-	       pt1_DOWN = pt1 * ES_DOWN_scale1;
-	       pt2_DOWN = pt2 * ES_DOWN_scale2;
-	       double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	       double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-	       dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-	       metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
-	       
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, svFitEta_DM1_DOWN, svFitPhi_DM1_DOWN, svFitMET_DM1_DOWN, svFitTransverseMass_DM1_DOWN, tau1_DM1_down, tau2_DM1_down);
-	     }
-	     else {
-	       svFitMass_DM1_DOWN=svFitMass;
-	       svFitPt_DM1_DOWN=svFitPt;
-	       svFitEta_DM1_DOWN=svFitEta;
-	       svFitPhi_DM1_DOWN=svFitPhi;
-	       svFitMET_DM1_DOWN=svFitMET;
-	       svFitTransverseMass_DM1_DOWN=svFitTransverseMass;
-	       tau1_DM1_down =  tau1;
-	       tau2_DM1_down =  tau2;
-	     }
-	     
-	     //*****************************************************
-	     //************* Tau DM10 shifted down *****************
-	     //*****************************************************
-	     
-	     if ((decayMode==10 && gen_match_1==5) or (decayMode2==10 && gen_match_2==5)){
-	       std::cout << "DM10 DOWN  ---  ";
-	       float ES_DOWN_scale1 = 1.0;
-	       float ES_DOWN_scale2 = 1.0;
-	       if (decayMode==10 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
-	       if (decayMode2==10 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
-	       double pt1_DOWN, pt2_DOWN;
-	       pt1_DOWN = pt1 * ES_DOWN_scale1;
-	       pt2_DOWN = pt2 * ES_DOWN_scale2;
-	       double metcorr_ex_DOWN, metcorr_ey_DOWN;
-	       double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
-	       dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
-	       dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
-	       metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
-	       metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
-	       
-	       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
-	       if (pt1 > pt2) {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-	       }
-	       else {
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2, pt2_DOWN, eta2, phi2, mass2, decayMode2));
-		 measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1, phi1, mass1, decayMode));
-	       }
-	       
-	       runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, svFitEta_DM10_DOWN, svFitPhi_DM10_DOWN, svFitMET_DM10_DOWN, svFitTransverseMass_DM10_DOWN, tau1_DM10_down, tau2_DM10_down);
-	     }
-	     else {
-	       svFitMass_DM10_DOWN=svFitMass;
-	       svFitPt_DM10_DOWN=svFitPt;
-	       svFitEta_DM10_DOWN=svFitEta;
-	       svFitPhi_DM10_DOWN=svFitPhi;
-	       svFitMET_DM10_DOWN=svFitMET;
-	       svFitTransverseMass_DM10_DOWN=svFitTransverseMass;
-	       tau1_DM10_down = tau1;
-	       tau2_DM10_down = tau2;
-	     }
-	   }// Do ES (TT)
-	   
-	 } // Double Hadronic (TT)
-	 
-	 else {
-	   svFitMass = -100;
-	   svFitPt = -100;
-	   svFitEta = -100;
-	   svFitPhi = -100;
-	   svFitMET = -100;
-	   svFitTransverseMass = -100;
-	   tau1.SetPtEtaPhiM(0,0,0,0);
-	   tau2.SetPtEtaPhiM(0,0,0,0); 
-	 }
-	 // fill the tau 4-vector parameters for branch-filling
-	 tau1_pt  = tau1.Pt();
-	 tau1_eta = tau1.Eta();
-	 tau1_phi = tau1.Phi();
-	 tau1_m   = tau1.M();
-	 tau2_pt  = tau2.Pt();
-	 tau2_eta = tau2.Eta();
-	 tau2_phi = tau2.Phi();
-	 tau2_m   = tau2.M();
-	 // up
-	 tau1_pt_UP  = tau1_up.Pt();
-	 tau1_eta_UP = tau1_up.Eta();
-	 tau1_phi_UP = tau1_up.Phi();
-	 tau1_m_UP   = tau1_up.M();
-	 tau2_pt_UP  = tau2_up.Pt();
-	 tau2_eta_UP = tau2_up.Eta();
-	 tau2_phi_UP = tau2_up.Phi();
-	 tau2_m_UP   = tau2_up.M();
-	 // down
-	 tau1_pt_DOWN  = tau1_down.Pt();
-	 tau1_eta_DOWN = tau1_down.Eta();
-	 tau1_phi_DOWN = tau1_down.Phi();
-	 tau1_m_DOWN   = tau1_down.M();
-	 tau2_pt_DOWN  = tau2_down.Pt();
-	 tau2_eta_DOWN = tau2_down.Eta();
-	 tau2_phi_DOWN = tau2_down.Phi();
-	 tau2_m_DOWN   = tau2_down.M();
-	 // DM0 up
-	 tau1_pt_DM0_UP  = tau1_DM0_up.Pt();
-	 tau1_eta_DM0_UP = tau1_DM0_up.Eta();
-	 tau1_phi_DM0_UP = tau1_DM0_up.Phi();
-	 tau1_m_DM0_UP   = tau1_DM0_up.M();
-	 tau2_pt_DM0_UP  = tau2_DM0_up.Pt();
-	 tau2_eta_DM0_UP = tau2_DM0_up.Eta();
-	 tau2_phi_DM0_UP = tau2_DM0_up.Phi();
-	 tau2_m_DM0_UP   = tau2_DM0_up.M();
-	 // down
-	 tau1_pt_DM0_DOWN  = tau1_DM0_down.Pt();
-	 tau1_eta_DM0_DOWN = tau1_DM0_down.Eta();
-	 tau1_phi_DM0_DOWN = tau1_DM0_down.Phi();
-	 tau1_m_DM0_DOWN   = tau1_DM0_down.M();
-	 tau2_pt_DM0_DOWN  = tau2_DM0_down.Pt();
-	 tau2_eta_DM0_DOWN = tau2_DM0_down.Eta();
-	 tau2_phi_DM0_DOWN = tau2_DM0_down.Phi();
-	 tau2_m_DM0_DOWN   = tau2_DM0_down.M();
-	 // DM1 up
-	 tau1_pt_DM1_UP  = tau1_DM1_up.Pt();
-	 tau1_eta_DM1_UP = tau1_DM1_up.Eta();
-	 tau1_phi_DM1_UP = tau1_DM1_up.Phi();
-	 tau1_m_DM1_UP   = tau1_DM1_up.M();
-	 tau2_pt_DM1_UP  = tau2_DM1_up.Pt();
-	 tau2_eta_DM1_UP = tau2_DM1_up.Eta();
-	 tau2_phi_DM1_UP = tau2_DM1_up.Phi();
-	 tau2_m_DM1_UP   = tau2_DM1_up.M();
-	 // down
-	 tau1_pt_DM1_DOWN  = tau1_DM1_down.Pt();
-	 tau1_eta_DM1_DOWN = tau1_DM1_down.Eta();
-	 tau1_phi_DM1_DOWN = tau1_DM1_down.Phi();
-	 tau1_m_DM1_DOWN   = tau1_DM1_down.M();
-	 tau2_pt_DM1_DOWN  = tau2_DM1_down.Pt();
-	 tau2_eta_DM1_DOWN = tau2_DM1_down.Eta();
-	 tau2_phi_DM1_DOWN = tau2_DM1_down.Phi();
-	 tau2_m_DM1_DOWN   = tau2_DM1_down.M();
-	 // DM10 up
-	 tau1_pt_DM10_UP  = tau1_DM10_up.Pt();
-	 tau1_eta_DM10_UP = tau1_DM10_up.Eta();
-	 tau1_phi_DM10_UP = tau1_DM10_up.Phi();
-	 tau1_m_DM10_UP   = tau1_DM10_up.M();
-	 tau2_pt_DM10_UP  = tau2_DM10_up.Pt();
-	 tau2_eta_DM10_UP = tau2_DM10_up.Eta();
-	 tau2_phi_DM10_UP = tau2_DM10_up.Phi();
-	 tau2_m_DM10_UP   = tau2_DM10_up.M();
-	 // down
-	 tau1_pt_DM10_DOWN  = tau1_DM10_down.Pt();
-	 tau1_eta_DM10_DOWN = tau1_DM10_down.Eta();
-	 tau1_phi_DM10_DOWN = tau1_DM10_down.Phi();
-	 tau1_m_DM10_DOWN   = tau1_DM10_down.M();
-	 tau2_pt_DM10_DOWN  = tau2_DM10_down.Pt();
-	 tau2_eta_DM10_DOWN = tau2_DM10_down.Eta();
-	 tau2_phi_DM10_DOWN = tau2_DM10_down.Phi();
-	 tau2_m_DM10_DOWN   = tau2_DM10_down.M();
-	 // UncMet up
-	 tau1_pt_UncMet_UP  = tau1_UncMet_up.Pt();
-	 tau1_eta_UncMet_UP = tau1_UncMet_up.Eta();
-	 tau1_phi_UncMet_UP = tau1_UncMet_up.Phi();
-	 tau1_m_UncMet_UP   = tau1_UncMet_up.M();
-	 tau2_pt_UncMet_UP  = tau2_UncMet_up.Pt();
-	 tau2_eta_UncMet_UP = tau2_UncMet_up.Eta();
-	 tau2_phi_UncMet_UP = tau2_UncMet_up.Phi();
-	 tau2_m_UncMet_UP   = tau2_UncMet_up.M();
-	 // down
-	 tau1_pt_UncMet_DOWN  = tau1_UncMet_down.Pt();
-	 tau1_eta_UncMet_DOWN = tau1_UncMet_down.Eta();
-	 tau1_phi_UncMet_DOWN = tau1_UncMet_down.Phi();
-	 tau1_m_UncMet_DOWN   = tau1_UncMet_down.M();
-	 tau2_pt_UncMet_DOWN  = tau2_UncMet_down.Pt();
-	 tau2_eta_UncMet_DOWN = tau2_UncMet_down.Eta();
-	 tau2_phi_UncMet_DOWN = tau2_UncMet_down.Phi();
-	 tau2_m_UncMet_DOWN   = tau2_UncMet_down.M();
-	 // UnclusteredMet up
-	 tau1_pt_ClusteredMet_UP  = tau1_ClusteredMet_up.Pt();
-	 tau1_eta_ClusteredMet_UP = tau1_ClusteredMet_up.Eta();
-	 tau1_phi_ClusteredMet_UP = tau1_ClusteredMet_up.Phi();
-	 tau1_m_ClusteredMet_UP   = tau1_ClusteredMet_up.M();
-	 tau2_pt_ClusteredMet_UP  = tau2_ClusteredMet_up.Pt();
-	 tau2_eta_ClusteredMet_UP = tau2_ClusteredMet_up.Eta();
-	 tau2_phi_ClusteredMet_UP = tau2_ClusteredMet_up.Phi();
-	 tau2_m_ClusteredMet_UP   = tau2_ClusteredMet_up.M();
-	 // down
-	 tau1_pt_ClusteredMet_DOWN  = tau1_ClusteredMet_down.Pt();
-	 tau1_eta_ClusteredMet_DOWN = tau1_ClusteredMet_down.Eta();
-	 tau1_phi_ClusteredMet_DOWN = tau1_ClusteredMet_down.Phi();
-	 tau1_m_ClusteredMet_DOWN   = tau1_ClusteredMet_down.M();
-	 tau2_pt_ClusteredMet_DOWN  = tau2_ClusteredMet_down.Pt();
-	 tau2_eta_ClusteredMet_DOWN = tau2_ClusteredMet_down.Eta();
-	 tau2_phi_ClusteredMet_DOWN = tau2_ClusteredMet_down.Phi();
-	 tau2_m_ClusteredMet_DOWN   = tau2_ClusteredMet_down.M();
-	 
-	 
-	 std::cout << "\n\n" << std::endl;
-	 //std::cout << "\n\nex: " << metcorr_ex << "   ey: " << metcorr_ey <<  " phi: " << metcorphi<<"\n"<<std::endl; 
-	 newBranch1->Fill();
-	 newBranch2->Fill();
-	 newBranch3->Fill();
-	 newBranch4->Fill();
-	 newBranch5->Fill();
-	 newBranch6->Fill();
-	 newBranch7->Fill();
-	 newBranch8->Fill();
-	 newBranch9->Fill();
-	 newBranch10->Fill();
-	 
-	 newBranch11->Fill();
-	 newBranch12->Fill();
-	 newBranch13->Fill();
-	 newBranch14->Fill();
-	 newBranch15->Fill();
-	 newBranch16->Fill();
-	 newBranch17->Fill();
-	 newBranch18->Fill();
-	 newBranch19->Fill();
-	 newBranch20->Fill();
-	 newBranch21->Fill();
-	 newBranch22->Fill();
-	 
-	 newBranch23->Fill();
-	 newBranch24->Fill();
-	 newBranch25->Fill();
-	 newBranch26->Fill();
-	 newBranch27->Fill();
-	 newBranch28->Fill();
-	 newBranch29->Fill();
-	 newBranch30->Fill();
-	 newBranch31->Fill();
-	 newBranch32->Fill();
-	 newBranch33->Fill();
-	 newBranch34->Fill();
-	 
-	 newBranch35->Fill();
-	 newBranch36->Fill();
-	 newBranch37->Fill();
-	 newBranch38->Fill();
-	 newBranch39->Fill();
-	 newBranch40->Fill();
-	 newBranch41->Fill();
-	 newBranch42->Fill();
-	 newBranch43->Fill();
-	 newBranch44->Fill();
-	 newBranch45->Fill();
-	 newBranch46->Fill();
-	 
-	 newBranch47->Fill();
-	 newBranch48->Fill();
-	 newBranch49->Fill();
-	 newBranch50->Fill();
-	 newBranch51->Fill();
-	 newBranch52->Fill();
-	 newBranch53->Fill();
-	 newBranch54->Fill();
-	 newBranch55->Fill();
-	 newBranch56->Fill();
-	 newBranch57->Fill();
-	 newBranch58->Fill();
-	 
-	 newBranch59->Fill();
-	 newBranch60->Fill();
-	 newBranch61->Fill();
-	 newBranch62->Fill();
-	 newBranch63->Fill();
-	 newBranch64->Fill();
-	 newBranch65->Fill();
-	 newBranch66->Fill();
-	 newBranch67->Fill();
-	 newBranch68->Fill();
-	 newBranch69->Fill();
-	 newBranch70->Fill();
-	 
-	 newBranch71->Fill();
-	 newBranch72->Fill();
-	 newBranch73->Fill();
-	 newBranch74->Fill();
-	 newBranch75->Fill();
-	 newBranch76->Fill();
-	 newBranch77->Fill();
-	 newBranch78->Fill();
-	 newBranch79->Fill();
-	 newBranch80->Fill();
-	 newBranch81->Fill();
-	 newBranch82->Fill();
-	 
-	 newBranch83->Fill();
-	 newBranch84->Fill();
-	 newBranch85->Fill();
-	 newBranch86->Fill();
-	 newBranch87->Fill();
-	 newBranch89->Fill();
-	 newBranch90->Fill();
-	 newBranch91->Fill();
-	 
-	 for(unsigned int i = 0; i != tau4VectorBranches.size(); ++i)
-	   (tau4VectorBranches[i])->Fill();
-	 
+              
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+            } else {
+              svFitMass_UP=svFitMass;
+              svFitPt_UP=svFitPt;
+              svFitEta_UP=svFitEta;
+              svFitPhi_UP=svFitPhi;
+              svFitMET_UP=svFitMET;
+              svFitTransverseMass_UP=svFitTransverseMass;
+              tau1_up = tau1;
+              tau2_up = tau2;
+            }
+            
+            // Second ES Down, x 0.97
+            if (gen_match_2<=5){
+              float ES_DOWN_scale=1.0; // jet
+              if (gen_match_2==5) ES_DOWN_scale=tesDOWN; // tau
+              if (gen_match_2<5) ES_DOWN_scale=0.990;  // elec/mu
+              double pt2_DOWN;
+              pt2_DOWN = pt2 * ES_DOWN_scale;
+              double metcorr_ex_DOWN, metcorr_ey_DOWN;
+              double dx2_DOWN, dy2_DOWN;
+              dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
+              dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
+              metcorr_ex_DOWN = metcorr_ex + dx2_DOWN;
+              metcorr_ey_DOWN = metcorr_ey + dy2_DOWN;
+              
+              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;          
+              measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
+              measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+              
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+            } else {
+              svFitMass_DOWN=svFitMass;
+              svFitPt_DOWN=svFitPt;
+              svFitEta_DOWN=svFitEta;
+              svFitPhi_DOWN=svFitPhi;
+              svFitMET_DOWN=svFitMET;
+              svFitTransverseMass_DOWN=svFitTransverseMass;
+              tau1_down = tau1;
+              tau2_down = tau2;
+            }
+          } // end doES
+        } // eTau / muTau
+     
+     else if(channel=="em"){
+       // define lepton four vectors
+       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons;
+       measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
+       measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2, mass2));
+       
+       std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
+       runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
+       std::cout<<"finished running non-EES SVFit in EMu"<<std::endl;
+       if(doES) {
+         
+         // Only shift Electrons
+         // 1% shift in barrel and 2.5% shift in endcap
+         // applied to electrons in emu channel
+         float etaBarrelEndcap  = 1.479;
+         float ES_UP_scale;
+         if (abs(eta1) < etaBarrelEndcap) ES_UP_scale = 1.01;
+         else ES_UP_scale = 1.025;
+         double pt1_UP = pt1 * ES_UP_scale;
+         std::cout << "E eta: " << eta1 << " ees SF: " << ES_UP_scale << std::endl;
+         double metcorr_ex_UP, metcorr_ey_UP;
+         double dx1_UP, dy1_UP;
+         dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale ) - 1.);
+         dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale ) - 1.);
+         metcorr_ex_UP = metcorr_ex + dx1_UP;
+         metcorr_ey_UP = metcorr_ey + dy1_UP;
+         std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_UP <<std::endl;
+         std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_UP <<std::endl;
+         std::cout << "pt1 " << pt1 << "  pt1_up " << pt1_UP <<std::endl;
+         std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_UP << std::endl;
+         std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_UP << std::endl;
+         
+         std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2, mass2));
+         
+         std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1_UP << " mass1 " << mass1 << " pt2: "<< pt2 << " mass2: "<< mass2 <<std::endl;        
+         runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+         std::cout<<"finished runningSVFit in EMu EES Up"<<std::endl;
+         
+         
+         // EES Down
+         float ES_DOWN_scale;
+         if (abs(eta1) < etaBarrelEndcap) ES_DOWN_scale = 0.99;
+         else ES_DOWN_scale = 0.975;
+         std::cout << "E eta: " << eta1 << " ees SF: " << ES_DOWN_scale << std::endl;
+         double pt1_DOWN;
+         pt1_DOWN = pt1 * ES_DOWN_scale;
+         double metcorr_ex_DOWN, metcorr_ey_DOWN;
+         double dx1_DOWN, dy1_DOWN;
+         dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale ) - 1.);
+         dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale ) - 1.);
+         metcorr_ex_DOWN = metcorr_ex + dx1_DOWN;
+         metcorr_ey_DOWN = metcorr_ey + dy1_DOWN;
+         std::cout << "px1 " << pt1 * TMath::Cos( phi1 ) << "  met px1 cor " << dx1_DOWN <<std::endl;
+         std::cout << "py1 " << pt1 * TMath::Sin( phi1 ) << "  met py1 cor " << dy1_DOWN <<std::endl;
+         std::cout << "metcor_ex " << metcorr_ex << " ees: " << metcorr_ex_DOWN << std::endl;
+         std::cout << "metcor_ey " << metcorr_ey << " ees: " << metcorr_ey_DOWN << std::endl;
+         
+         std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2));
+         
+         runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+         
+         
+       } // end doES
+     } // eMu
+     
+     
+     
+     else if(channel=="tt"){
+       
+       float shiftTau1=1.0;
+       float shiftTau2=1.0;
+       if (gen_match_1==5 && decayMode==0) shiftTau1=0.982;
+       if (gen_match_1==5 && decayMode==1) shiftTau1=1.010;
+       if (gen_match_1==5 && decayMode==10) shiftTau1=1.004;
+       if (gen_match_2==5 && decayMode2==0) shiftTau2=0.982;
+       if (gen_match_2==5 && decayMode2==1) shiftTau2=1.010;
+       if (gen_match_2==5 && decayMode2==10) shiftTau2=1.004;
+       pt1 = pt1 * shiftTau1;
+       pt2 = pt2 * shiftTau2;
+       double dx1, dy1;
+       double dx2, dy2;
+       dx1 = pt1 * TMath::Cos( phi1 ) * (( 1. / shiftTau1 ) - 1.);
+       dy1 = pt1 * TMath::Sin( phi1 ) * (( 1. / shiftTau1 ) - 1.);
+       dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau2 ) - 1.);
+       dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau2 ) - 1.);
+       metcorr_ex = metcorr_ex + dx1;
+       metcorr_ey = metcorr_ey + dy1;
+       metcorr_ex = metcorr_ex + dx2;
+       metcorr_ey = metcorr_ey + dy2;
+       
+       // define lepton four vectors
+       std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons;
+       // Add Tau of higest Pt first
+       if (pt1 > pt2) {
+         measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1, decayMode));
+         
+         measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2));
+       }
+       else {
+         measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2, eta2, phi2,  mass2, decayMode2));
+         
+         measuredTauLeptons.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1, decayMode));
+       }
+       
+       std::cout<< "evt: "<<evt<<" run: "<<run<<" lumi: "<<lumi<< " pt1 " << pt1 << " mass1 " << mass1 << " pt2: "<< pt2<< " mass2: "<< mass2 <<std::endl;        
+       runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
+       std::cout<<"finished running non-TES SVFit in TT"<<std::endl;
+       
+       
+       //*****************************************************
+       // MET SYSTEMATICS
+       // Taus Pt have been corrected (TEC)
+       // Still need TEC propagated to shifted METs
+       //*****************************************************
+       
+       std::cout << "MET Unclustered Energy Up   ---  ";
+       metcorrUncUp_ex = metcorrUncUp_ex + dx1 + dx2;
+       metcorrUncUp_ey = metcorrUncUp_ey + dy1 + dy2;
+       runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_UP, svFitPt_UncMet_UP, svFitEta_UncMet_UP, svFitPhi_UncMet_UP, svFitMET_UncMet_UP, svFitTransverseMass_UncMet_UP, tau1_UncMet_up, tau2_UncMet_up);
+       std::cout << "MET Unclustered Energy Down ---  ";
+       metcorrUncDown_ex = metcorrUncDown_ex + dx1 + dx2;
+       metcorrUncDown_ey = metcorrUncDown_ey + dy1 + dy2;
+       runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_DOWN, svFitPt_UncMet_DOWN, svFitEta_UncMet_DOWN, svFitPhi_UncMet_DOWN, svFitMET_UncMet_DOWN, svFitTransverseMass_UncMet_DOWN, tau1_UncMet_down, tau2_UncMet_down);
+       std::cout << "MET Clustered Energy Up     ---  ";
+       metcorrClusteredUp_ex = metcorrClusteredUp_ex + dx1 + dx2;
+       metcorrClusteredUp_ey = metcorrClusteredUp_ey + dy1 + dy2;
+       runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_UP, svFitPt_ClusteredMet_UP, svFitEta_ClusteredMet_UP, svFitPhi_ClusteredMet_UP, svFitMET_ClusteredMet_UP, svFitTransverseMass_ClusteredMet_UP, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
+       std::cout << "MET Clustered Energy Down   ---  ";
+       metcorrClusteredDown_ex = metcorrClusteredDown_ex + dx1 + dx2;
+       metcorrClusteredDown_ey = metcorrClusteredDown_ey + dy1 + dy2;
+       runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_DOWN, svFitPt_ClusteredMet_DOWN, svFitEta_ClusteredMet_DOWN, svFitPhi_ClusteredMet_DOWN, svFitMET_ClusteredMet_DOWN, svFitTransverseMass_ClusteredMet_DOWN, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
+       std::cout<< "Shifted MET Summary:\nmetcorr_ex " << metcorr_ex << "\n --- metcorrUncUp_ex " << metcorrUncUp_ex << " metcorrUncDown_ex " << metcorrUncDown_ex
+            << " metcorrClusteredUp_ex " << metcorrClusteredUp_ex << " metcorrClusteredDown_ex " << metcorrClusteredDown_ex << std::endl;
+       std::cout<< "metcorr_ey " << metcorr_ey << "\n --- metcorrUncUp_ey " << metcorrUncUp_ey << " metcorrUncDown_ey " << metcorrUncDown_ey
+            << " metcorrClusteredUp_ey " << metcorrClusteredUp_ey << " metcorrClusteredDown_ey " << metcorrClusteredDown_ey << std::endl;
+       
+       
+       // Corrected MET values for saving
+       metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
+       metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
+       metcorClusteredDown = TMath::Sqrt( metcorrClusteredDown_ex*metcorrClusteredDown_ex + metcorrClusteredDown_ey*metcorrClusteredDown_ey);
+       metcorphiClusteredDown = TMath::ATan2( metcorrClusteredDown_ey, metcorrClusteredDown_ex );
+       metcorClusteredUp = TMath::Sqrt( metcorrClusteredUp_ex*metcorrClusteredUp_ex + metcorrClusteredUp_ey*metcorrClusteredUp_ey);
+       metcorphiClusteredUp = TMath::ATan2( metcorrClusteredUp_ey, metcorrClusteredUp_ex );
+       metcorUncDown = TMath::Sqrt( metcorrUncDown_ex*metcorrUncDown_ex + metcorrUncDown_ey*metcorrUncDown_ey);
+       metcorphiUncDown = TMath::ATan2( metcorrUncDown_ey, metcorrUncDown_ex );
+       metcorUncUp = TMath::Sqrt( metcorrUncUp_ex*metcorrUncUp_ex + metcorrUncUp_ey*metcorrUncUp_ey);
+       metcorphiUncUp = TMath::ATan2( metcorrUncUp_ey, metcorrUncUp_ex );
+       
+       if(doES) {
+         
+         //***************************************************************************
+         //********************* Two taus shifted up *********************************
+         //***************************************************************************
+         
+         if (gen_match_2==5 or gen_match_1==5){
+           std::cout << "Two UP    ---  ";
+           float ES_UP_scale1 = 1.0;
+           float ES_UP_scale2 = 1.0;
+           if(gen_match_1==5) ES_UP_scale1 = tesUP;
+           if(gen_match_2==5) ES_UP_scale2 = tesUP;
+           std::cout << "TES values: gen1: " << gen_match_1 << "   dm_1: " << decayMode;
+           std::cout << "   tes1: " << ES_UP_scale1;
+           std::cout << "   gen2: " << gen_match_2 << "   dm_2: " << decayMode2;
+           std::cout << "   tes2: " << ES_UP_scale2 << std::endl;
+           double pt1_UP, pt2_UP;
+           pt1_UP = pt1 * ES_UP_scale1;
+           pt2_UP = pt2 * ES_UP_scale2;
+           double metcorr_ex_UP, metcorr_ey_UP;
+           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
+           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
+           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
+           
+           // Add Tau of higest Pt first
+           if (pt1 > pt2) {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+         }
+         else {
+           svFitMass_UP=svFitMass;
+           svFitPt_UP=svFitPt;
+           svFitEta_UP=svFitEta;
+           svFitPhi_UP=svFitPhi;
+           svFitMET_UP=svFitMET;
+           svFitTransverseMass_UP=svFitTransverseMass;
+           tau1_up = tau1;
+           tau2_up = tau2;
+         }
+         
+         //***************************************************************************
+         //********************** Tau DM0 shifted up *********************************
+         //***************************************************************************
+         
+         if ((gen_match_2==5 && decayMode2==0) or (gen_match_1==5 && decayMode==0)){
+           std::cout << "DM0 UP    ---  ";
+           float ES_UP_scale1 = 1.0;
+           float ES_UP_scale2 = 1.0;
+           if(gen_match_1==5 && decayMode==0) ES_UP_scale1 = tesUP;
+           if(gen_match_2==5 && decayMode2==0) ES_UP_scale2 = tesUP;
+           double pt1_UP, pt2_UP;
+           pt1_UP = pt1 * ES_UP_scale1;
+           pt2_UP = pt2 * ES_UP_scale2;
+           double metcorr_ex_UP, metcorr_ey_UP;
+           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
+           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
+           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
+           // Add Tau of higest Pt first
+           if (pt1 > pt2) {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM0_UP, svFitPt_DM0_UP, svFitEta_DM0_UP, svFitPhi_DM0_UP, svFitMET_DM0_UP, svFitTransverseMass_DM0_UP, tau1_DM0_up, tau2_DM0_down);
+         }
+         else {
+           svFitMass_DM0_UP=svFitMass;
+           svFitPt_DM0_UP=svFitPt;
+           svFitEta_DM0_UP=svFitEta;
+           svFitPhi_DM0_UP=svFitPhi;
+           svFitMET_DM0_UP=svFitMET;
+           svFitTransverseMass_DM0_UP=svFitTransverseMass;
+           tau1_DM0_up = tau1;
+           tau2_DM0_down = tau2;
+         }
+         
+         //***************************************************************************
+         //********************** Tau DM1 shifted up *********************************
+         //***************************************************************************
+         
+         if ((decayMode==1 && gen_match_1==5) or (decayMode2==1 && gen_match_2==5)){
+           std::cout << "DM1 UP    ---  ";
+           float ES_UP_scale1 = 1.0;
+           float ES_UP_scale2 = 1.0;
+           if (decayMode==1 && gen_match_1==5) ES_UP_scale1 = tesUP;
+           if (decayMode2==1 && gen_match_2==5) ES_UP_scale2 = tesUP;
+           double pt1_UP, pt2_UP;
+           pt1_UP = pt1 * ES_UP_scale1;
+           pt2_UP = pt2 * ES_UP_scale2;
+           double metcorr_ex_UP, metcorr_ey_UP;
+           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
+           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
+           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
+           // Add Tau of higest Pt first
+           if (pt1 > pt2) {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, svFitEta_DM1_UP, svFitPhi_DM1_UP, svFitMET_DM1_UP, svFitTransverseMass_DM1_UP, tau1_DM1_up, tau2_DM1_up);
+         }
+         else {
+           svFitMass_DM1_UP=svFitMass;
+           svFitPt_DM1_UP=svFitPt;
+           svFitEta_DM1_UP=svFitEta;
+           svFitPhi_DM1_UP=svFitPhi;
+           svFitMET_DM1_UP=svFitMET;
+           svFitTransverseMass_DM1_UP=svFitTransverseMass;
+           tau1_DM1_up = tau1;
+           tau2_DM1_up = tau2;
+         }
+         
+         //***************************************************************************
+         //********************* Tau DM10 shifted up *********************************
+         //***************************************************************************
+         
+         if ((decayMode2==10 && gen_match_2==5) or (decayMode==10 && gen_match_1==5)){
+           std::cout << "DM10 UP    ---  ";
+           float ES_UP_scale1 = 1.0;
+           float ES_UP_scale2 = 1.0;
+           if(decayMode==10 && gen_match_1==5) ES_UP_scale1 = tesUP;
+           if(decayMode2==10 && gen_match_2==5) ES_UP_scale2 = tesUP;
+           double pt1_UP, pt2_UP;
+           pt1_UP = pt1 * ES_UP_scale1;
+           pt2_UP = pt2 * ES_UP_scale2;
+           double metcorr_ex_UP, metcorr_ey_UP;
+           double dx1_UP, dy1_UP, dx2_UP, dy2_UP;
+           dx1_UP = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dy1_UP = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_UP_scale1 ) - 1.);
+           dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale2 ) - 1.);
+           metcorr_ex_UP = metcorr_ex + dx1_UP + dx2_UP;
+           metcorr_ey_UP = metcorr_ey + dy1_UP + dy2_UP;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP;
+           
+           // Add Tau of higest Pt first
+           if (pt1 > pt2) {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsUP.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_UP, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, svFitEta_DM10_UP, svFitPhi_DM10_UP, svFitMET_DM10_UP, svFitTransverseMass_DM10_UP, tau1_DM10_up, tau2_DM10_up);
+         }
+         else {
+           svFitMass_DM10_UP=svFitMass;
+           svFitPt_DM10_UP=svFitPt;
+           svFitEta_DM10_UP=svFitEta;
+           svFitPhi_DM10_UP=svFitPhi;
+           svFitMET_DM10_UP=svFitMET;
+           svFitTransverseMass_DM10_UP=svFitTransverseMass;
+           tau1_DM10_up = tau1;
+           tau2_DM10_up = tau2;
+         }
+         
+         //*****************************************************
+         //************* Two taus shifted down *****************
+         //*****************************************************
+         
+         if (gen_match_1==5 or gen_match_2==5){
+           std::cout << "Two DOWN  ---  ";
+           float ES_DOWN_scale1 = 1.0;
+           float ES_DOWN_scale2 = 1.0;
+           if (gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
+           if (gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
+           double pt1_DOWN, pt2_DOWN;
+           pt1_DOWN = pt1 * ES_DOWN_scale1;
+           pt2_DOWN = pt2 * ES_DOWN_scale2;
+           double metcorr_ex_DOWN, metcorr_ey_DOWN;
+           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
+           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
+           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
+           
+           if (pt1 > pt2) {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+         }
+         else {
+           svFitMass_DOWN=svFitMass;
+           svFitPt_DOWN=svFitPt;
+           svFitEta_DOWN=svFitEta;
+           svFitPhi_DOWN=svFitPhi;
+           svFitMET_DOWN=svFitMET;
+           svFitTransverseMass_DOWN=svFitTransverseMass;
+           tau1_down = tau1;
+           tau2_down = tau2;
+         }
+         
+         //*****************************************************
+         //************* Tau DM0 shifted down  *****************
+         //*****************************************************
+         
+         if ((decayMode==0 && gen_match_1==5) or (decayMode2==0 && gen_match_2==5)){
+           std::cout << "DM0 DOWN  ---  ";
+           float ES_DOWN_scale1 = 1.0;
+           float ES_DOWN_scale2 = 1.0;
+           if (decayMode==0 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
+           if (decayMode2==0 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
+           double pt1_DOWN, pt2_DOWN;
+           pt1_DOWN = pt1 * ES_DOWN_scale1;
+           pt2_DOWN = pt2 * ES_DOWN_scale2;
+           double metcorr_ex_DOWN, metcorr_ey_DOWN;
+           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
+           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
+           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
+           if (pt1 > pt2) {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM0_DOWN, svFitPt_DM0_DOWN, svFitEta_DM0_DOWN, svFitPhi_DM0_DOWN, svFitMET_DM0_DOWN, svFitTransverseMass_DM0_DOWN, tau1_DM0_down, tau2_DM0_down);
+         }
+         else {
+           svFitMass_DM0_DOWN=svFitMass;
+           svFitPt_DM0_DOWN=svFitPt;
+           svFitEta_DM0_DOWN=svFitEta;
+           svFitPhi_DM0_DOWN=svFitPhi;
+           svFitMET_DM0_DOWN=svFitMET;
+           svFitTransverseMass_DM0_DOWN=svFitTransverseMass;
+           tau1_DM0_down = tau1;
+           tau2_DM0_down = tau2;
+         }
+         
+         //*****************************************************
+         //************** Tau DM1 shifted down *****************
+         //*****************************************************
+         
+         if ((decayMode==1 && gen_match_1==5) or (decayMode2==1 && gen_match_2==5)){
+           std::cout << "DM1 DOWN  ---  ";
+           float ES_DOWN_scale1 = 1.0;
+           float ES_DOWN_scale2 = 1.0;
+           if (decayMode==1 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
+           if (decayMode2==1 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
+           double pt1_DOWN, pt2_DOWN;
+           pt1_DOWN = pt1 * ES_DOWN_scale1;
+           pt2_DOWN = pt2 * ES_DOWN_scale2;
+           double metcorr_ex_DOWN, metcorr_ey_DOWN;
+           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
+           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
+           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
+           
+           if (pt1 > pt2) {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, svFitEta_DM1_DOWN, svFitPhi_DM1_DOWN, svFitMET_DM1_DOWN, svFitTransverseMass_DM1_DOWN, tau1_DM1_down, tau2_DM1_down);
+         }
+         else {
+           svFitMass_DM1_DOWN=svFitMass;
+           svFitPt_DM1_DOWN=svFitPt;
+           svFitEta_DM1_DOWN=svFitEta;
+           svFitPhi_DM1_DOWN=svFitPhi;
+           svFitMET_DM1_DOWN=svFitMET;
+           svFitTransverseMass_DM1_DOWN=svFitTransverseMass;
+           tau1_DM1_down =  tau1;
+           tau2_DM1_down =  tau2;
+         }
+         
+         //*****************************************************
+         //************* Tau DM10 shifted down *****************
+         //*****************************************************
+         
+         if ((decayMode==10 && gen_match_1==5) or (decayMode2==10 && gen_match_2==5)){
+           std::cout << "DM10 DOWN  ---  ";
+           float ES_DOWN_scale1 = 1.0;
+           float ES_DOWN_scale2 = 1.0;
+           if (decayMode==10 && gen_match_1==5) ES_DOWN_scale1 = tesDOWN;
+           if (decayMode2==10 && gen_match_2==5) ES_DOWN_scale2 = tesDOWN;
+           double pt1_DOWN, pt2_DOWN;
+           pt1_DOWN = pt1 * ES_DOWN_scale1;
+           pt2_DOWN = pt2 * ES_DOWN_scale2;
+           double metcorr_ex_DOWN, metcorr_ey_DOWN;
+           double dx1_DOWN, dy1_DOWN, dx2_DOWN, dy2_DOWN;
+           dx1_DOWN = pt1 * TMath::Cos( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dy1_DOWN = pt1 * TMath::Sin( phi1 ) * (( 1. / ES_DOWN_scale1 ) - 1.);
+           dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale2 ) - 1.);
+           metcorr_ex_DOWN = metcorr_ex + dx1_DOWN + dx2_DOWN;
+           metcorr_ey_DOWN = metcorr_ey + dy1_DOWN + dy2_DOWN;
+           
+           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;
+           if (pt1 > pt2) {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1,  phi1, mass1, decayMode));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
+           }
+           else {
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2, pt2_DOWN, eta2, phi2, mass2, decayMode2));
+         measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1_DOWN, eta1, phi1, mass1, decayMode));
+           }
+           
+           runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, svFitEta_DM10_DOWN, svFitPhi_DM10_DOWN, svFitMET_DM10_DOWN, svFitTransverseMass_DM10_DOWN, tau1_DM10_down, tau2_DM10_down);
+         }
+         else {
+           svFitMass_DM10_DOWN=svFitMass;
+           svFitPt_DM10_DOWN=svFitPt;
+           svFitEta_DM10_DOWN=svFitEta;
+           svFitPhi_DM10_DOWN=svFitPhi;
+           svFitMET_DM10_DOWN=svFitMET;
+           svFitTransverseMass_DM10_DOWN=svFitTransverseMass;
+           tau1_DM10_down = tau1;
+           tau2_DM10_down = tau2;
+         }
+       }// Do ES (TT)
+       
+     } // Double Hadronic (TT)
+     
+     else {
+       svFitMass = -100;
+       svFitPt = -100;
+       svFitEta = -100;
+       svFitPhi = -100;
+       svFitMET = -100;
+       svFitTransverseMass = -100;
+       tau1.SetPtEtaPhiM(0,0,0,0);
+       tau2.SetPtEtaPhiM(0,0,0,0); 
+     }
+     // fill the tau 4-vector parameters for branch-filling
+     tau1_pt  = tau1.Pt();
+     tau1_eta = tau1.Eta();
+     tau1_phi = tau1.Phi();
+     tau1_m   = tau1.M();
+     tau2_pt  = tau2.Pt();
+     tau2_eta = tau2.Eta();
+     tau2_phi = tau2.Phi();
+     tau2_m   = tau2.M();
+     // up
+     tau1_pt_UP  = tau1_up.Pt();
+     tau1_eta_UP = tau1_up.Eta();
+     tau1_phi_UP = tau1_up.Phi();
+     tau1_m_UP   = tau1_up.M();
+     tau2_pt_UP  = tau2_up.Pt();
+     tau2_eta_UP = tau2_up.Eta();
+     tau2_phi_UP = tau2_up.Phi();
+     tau2_m_UP   = tau2_up.M();
+     // down
+     tau1_pt_DOWN  = tau1_down.Pt();
+     tau1_eta_DOWN = tau1_down.Eta();
+     tau1_phi_DOWN = tau1_down.Phi();
+     tau1_m_DOWN   = tau1_down.M();
+     tau2_pt_DOWN  = tau2_down.Pt();
+     tau2_eta_DOWN = tau2_down.Eta();
+     tau2_phi_DOWN = tau2_down.Phi();
+     tau2_m_DOWN   = tau2_down.M();
+     // DM0 up
+     tau1_pt_DM0_UP  = tau1_DM0_up.Pt();
+     tau1_eta_DM0_UP = tau1_DM0_up.Eta();
+     tau1_phi_DM0_UP = tau1_DM0_up.Phi();
+     tau1_m_DM0_UP   = tau1_DM0_up.M();
+     tau2_pt_DM0_UP  = tau2_DM0_up.Pt();
+     tau2_eta_DM0_UP = tau2_DM0_up.Eta();
+     tau2_phi_DM0_UP = tau2_DM0_up.Phi();
+     tau2_m_DM0_UP   = tau2_DM0_up.M();
+     // down
+     tau1_pt_DM0_DOWN  = tau1_DM0_down.Pt();
+     tau1_eta_DM0_DOWN = tau1_DM0_down.Eta();
+     tau1_phi_DM0_DOWN = tau1_DM0_down.Phi();
+     tau1_m_DM0_DOWN   = tau1_DM0_down.M();
+     tau2_pt_DM0_DOWN  = tau2_DM0_down.Pt();
+     tau2_eta_DM0_DOWN = tau2_DM0_down.Eta();
+     tau2_phi_DM0_DOWN = tau2_DM0_down.Phi();
+     tau2_m_DM0_DOWN   = tau2_DM0_down.M();
+     // DM1 up
+     tau1_pt_DM1_UP  = tau1_DM1_up.Pt();
+     tau1_eta_DM1_UP = tau1_DM1_up.Eta();
+     tau1_phi_DM1_UP = tau1_DM1_up.Phi();
+     tau1_m_DM1_UP   = tau1_DM1_up.M();
+     tau2_pt_DM1_UP  = tau2_DM1_up.Pt();
+     tau2_eta_DM1_UP = tau2_DM1_up.Eta();
+     tau2_phi_DM1_UP = tau2_DM1_up.Phi();
+     tau2_m_DM1_UP   = tau2_DM1_up.M();
+     // down
+     tau1_pt_DM1_DOWN  = tau1_DM1_down.Pt();
+     tau1_eta_DM1_DOWN = tau1_DM1_down.Eta();
+     tau1_phi_DM1_DOWN = tau1_DM1_down.Phi();
+     tau1_m_DM1_DOWN   = tau1_DM1_down.M();
+     tau2_pt_DM1_DOWN  = tau2_DM1_down.Pt();
+     tau2_eta_DM1_DOWN = tau2_DM1_down.Eta();
+     tau2_phi_DM1_DOWN = tau2_DM1_down.Phi();
+     tau2_m_DM1_DOWN   = tau2_DM1_down.M();
+     // DM10 up
+     tau1_pt_DM10_UP  = tau1_DM10_up.Pt();
+     tau1_eta_DM10_UP = tau1_DM10_up.Eta();
+     tau1_phi_DM10_UP = tau1_DM10_up.Phi();
+     tau1_m_DM10_UP   = tau1_DM10_up.M();
+     tau2_pt_DM10_UP  = tau2_DM10_up.Pt();
+     tau2_eta_DM10_UP = tau2_DM10_up.Eta();
+     tau2_phi_DM10_UP = tau2_DM10_up.Phi();
+     tau2_m_DM10_UP   = tau2_DM10_up.M();
+     // down
+     tau1_pt_DM10_DOWN  = tau1_DM10_down.Pt();
+     tau1_eta_DM10_DOWN = tau1_DM10_down.Eta();
+     tau1_phi_DM10_DOWN = tau1_DM10_down.Phi();
+     tau1_m_DM10_DOWN   = tau1_DM10_down.M();
+     tau2_pt_DM10_DOWN  = tau2_DM10_down.Pt();
+     tau2_eta_DM10_DOWN = tau2_DM10_down.Eta();
+     tau2_phi_DM10_DOWN = tau2_DM10_down.Phi();
+     tau2_m_DM10_DOWN   = tau2_DM10_down.M();
+     // UncMet up
+     tau1_pt_UncMet_UP  = tau1_UncMet_up.Pt();
+     tau1_eta_UncMet_UP = tau1_UncMet_up.Eta();
+     tau1_phi_UncMet_UP = tau1_UncMet_up.Phi();
+     tau1_m_UncMet_UP   = tau1_UncMet_up.M();
+     tau2_pt_UncMet_UP  = tau2_UncMet_up.Pt();
+     tau2_eta_UncMet_UP = tau2_UncMet_up.Eta();
+     tau2_phi_UncMet_UP = tau2_UncMet_up.Phi();
+     tau2_m_UncMet_UP   = tau2_UncMet_up.M();
+     // down
+     tau1_pt_UncMet_DOWN  = tau1_UncMet_down.Pt();
+     tau1_eta_UncMet_DOWN = tau1_UncMet_down.Eta();
+     tau1_phi_UncMet_DOWN = tau1_UncMet_down.Phi();
+     tau1_m_UncMet_DOWN   = tau1_UncMet_down.M();
+     tau2_pt_UncMet_DOWN  = tau2_UncMet_down.Pt();
+     tau2_eta_UncMet_DOWN = tau2_UncMet_down.Eta();
+     tau2_phi_UncMet_DOWN = tau2_UncMet_down.Phi();
+     tau2_m_UncMet_DOWN   = tau2_UncMet_down.M();
+     // UnclusteredMet up
+     tau1_pt_ClusteredMet_UP  = tau1_ClusteredMet_up.Pt();
+     tau1_eta_ClusteredMet_UP = tau1_ClusteredMet_up.Eta();
+     tau1_phi_ClusteredMet_UP = tau1_ClusteredMet_up.Phi();
+     tau1_m_ClusteredMet_UP   = tau1_ClusteredMet_up.M();
+     tau2_pt_ClusteredMet_UP  = tau2_ClusteredMet_up.Pt();
+     tau2_eta_ClusteredMet_UP = tau2_ClusteredMet_up.Eta();
+     tau2_phi_ClusteredMet_UP = tau2_ClusteredMet_up.Phi();
+     tau2_m_ClusteredMet_UP   = tau2_ClusteredMet_up.M();
+     // down
+     tau1_pt_ClusteredMet_DOWN  = tau1_ClusteredMet_down.Pt();
+     tau1_eta_ClusteredMet_DOWN = tau1_ClusteredMet_down.Eta();
+     tau1_phi_ClusteredMet_DOWN = tau1_ClusteredMet_down.Phi();
+     tau1_m_ClusteredMet_DOWN   = tau1_ClusteredMet_down.M();
+     tau2_pt_ClusteredMet_DOWN  = tau2_ClusteredMet_down.Pt();
+     tau2_eta_ClusteredMet_DOWN = tau2_ClusteredMet_down.Eta();
+     tau2_phi_ClusteredMet_DOWN = tau2_ClusteredMet_down.Phi();
+     tau2_m_ClusteredMet_DOWN   = tau2_ClusteredMet_down.M();
+     
+     
+     std::cout << "\n\n" << std::endl;
+     //std::cout << "\n\nex: " << metcorr_ex << "   ey: " << metcorr_ey <<  " phi: " << metcorphi<<"\n"<<std::endl; 
+     newBranch1->Fill();
+     newBranch2->Fill();
+     newBranch3->Fill();
+     newBranch4->Fill();
+     newBranch5->Fill();
+     newBranch6->Fill();
+     newBranch7->Fill();
+     newBranch8->Fill();
+     newBranch9->Fill();
+     newBranch10->Fill();
+     
+     newBranch11->Fill();
+     newBranch12->Fill();
+     newBranch13->Fill();
+     newBranch14->Fill();
+     newBranch15->Fill();
+     newBranch16->Fill();
+     newBranch17->Fill();
+     newBranch18->Fill();
+     newBranch19->Fill();
+     newBranch20->Fill();
+     newBranch21->Fill();
+     newBranch22->Fill();
+     
+     newBranch23->Fill();
+     newBranch24->Fill();
+     newBranch25->Fill();
+     newBranch26->Fill();
+     newBranch27->Fill();
+     newBranch28->Fill();
+     newBranch29->Fill();
+     newBranch30->Fill();
+     newBranch31->Fill();
+     newBranch32->Fill();
+     newBranch33->Fill();
+     newBranch34->Fill();
+     
+     newBranch35->Fill();
+     newBranch36->Fill();
+     newBranch37->Fill();
+     newBranch38->Fill();
+     newBranch39->Fill();
+     newBranch40->Fill();
+     newBranch41->Fill();
+     newBranch42->Fill();
+     newBranch43->Fill();
+     newBranch44->Fill();
+     newBranch45->Fill();
+     newBranch46->Fill();
+     
+     newBranch47->Fill();
+     newBranch48->Fill();
+     newBranch49->Fill();
+     newBranch50->Fill();
+     newBranch51->Fill();
+     newBranch52->Fill();
+     newBranch53->Fill();
+     newBranch54->Fill();
+     newBranch55->Fill();
+     newBranch56->Fill();
+     newBranch57->Fill();
+     newBranch58->Fill();
+     
+     newBranch59->Fill();
+     newBranch60->Fill();
+     newBranch61->Fill();
+     newBranch62->Fill();
+     newBranch63->Fill();
+     newBranch64->Fill();
+     newBranch65->Fill();
+     newBranch66->Fill();
+     newBranch67->Fill();
+     newBranch68->Fill();
+     newBranch69->Fill();
+     newBranch70->Fill();
+     
+     newBranch71->Fill();
+     newBranch72->Fill();
+     newBranch73->Fill();
+     newBranch74->Fill();
+     newBranch75->Fill();
+     newBranch76->Fill();
+     newBranch77->Fill();
+     newBranch78->Fill();
+     newBranch79->Fill();
+     newBranch80->Fill();
+     newBranch81->Fill();
+     newBranch82->Fill();
+     
+     newBranch83->Fill();
+     newBranch84->Fill();
+     newBranch85->Fill();
+     newBranch86->Fill();
+     newBranch87->Fill();
+     newBranch89->Fill();
+     newBranch90->Fill();
+     newBranch91->Fill();
+     
+     for(unsigned int i = 0; i != tau4VectorBranches.size(); ++i)
+       (tau4VectorBranches[i])->Fill();
+     
       }
       dir->cd();
       t->Write("",TObject::kOverwrite);
@@ -1881,9 +1881,9 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 }
 
 void runSVFit(std::vector<classic_svFit::MeasuredTauLepton> & measuredTauLeptons, 
-	      double measuredMETx, double measuredMETy, TMatrixD &covMET, float num, 
-	      float &svFitMass, float& svFitPt, float &svFitEta, float &svFitPhi, float &svFitMET, float &svFitTransverseMass, 
-	      TLorentzVector& tau1, TLorentzVector& tau2){
+          double measuredMETx, double measuredMETy, TMatrixD &covMET, float num, 
+          float &svFitMass, float& svFitPt, float &svFitEta, float &svFitPhi, float &svFitMET, float &svFitTransverseMass, 
+          TLorentzVector& tau1, TLorentzVector& tau2){
   
   svfitAlgorithm.integrate(measuredTauLeptons, measuredMETx, measuredMETy, covMET);
   if ( svfitAlgorithm.isValidSolution()) {

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -1047,7 +1047,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
               tau2_DM10_down = tau2;
             }
 
-	        
 	        if (gen_match_2<=5){
 	          float ES_UP_scale=1.0; // this value is for jet -> tau fakes
 	          if (gen_match_2<5) ES_UP_scale=1.01; // for gen matched ele/muon

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -51,7 +51,6 @@ int main (int argc, char* argv[])
   parser.addOption("branch",optutl::CommandLineParser::kString,"Branch","__svFit__");
   parser.addOption("newFile",optutl::CommandLineParser::kString,"newFile","newFile.root");
   parser.addOption("inputFile",optutl::CommandLineParser::kString,"input File");
-  parser.addOption("newOutputFile",optutl::CommandLineParser::kDouble,"New Output File",0.0);
   parser.addOption("doES",optutl::CommandLineParser::kDouble,"doES",0.0);
   parser.addOption("isWJets",optutl::CommandLineParser::kDouble,"isWJets",0.0);
   parser.addOption("metType",optutl::CommandLineParser::kDouble,"metType",-1.0); // 1 = mvamet, -1 = pf met
@@ -76,28 +75,20 @@ int main (int argc, char* argv[])
   
   TFile *fProduce;//= new TFile(parser.stringValue("newFile").c_str(),"UPDATE");
   
-  if(parser.doubleValue("newOutputFile")>0){
-    TFile *f = new TFile(parser.stringValue("inputFile").c_str(),"READ");
-    std::cout<<"Creating new outputfile"<<std::endl;
-    std::string newFileName = parser.stringValue("newFile");
-    
-    fProduce = new TFile(newFileName.c_str(),"RECREATE");
-    copyFiles(parser, f, fProduce);//new TFile(parser.stringValue("inputFile").c_str()+"SVFit","UPDATE");
-    fProduce = new TFile(newFileName.c_str(),"UPDATE");
-    std::cout<<"listing the directories================="<<std::endl;
-    fProduce->ls();
-    readdir(fProduce,parser,TreeToUse,parser.doubleValue("doES"),parser.doubleValue("isWJets"),
-            parser.doubleValue("metType"),parser.doubleValue("tesSize"));
-    
-    fProduce->Close();
-    f->Close();
-  }
-  else{
-    TFile *f = new TFile(parser.stringValue("inputFile").c_str(),"UPDATE");
-    readdir(f,parser,TreeToUse,parser.doubleValue("doES"),parser.doubleValue("isWJets"),
-            parser.doubleValue("metType"),parser.doubleValue("tesSize"));
-    f->Close();
-  }
+  TFile *f = new TFile(parser.stringValue("inputFile").c_str(),"READ");
+  std::cout<<"Creating new outputfile"<<std::endl;
+  std::string newFileName = parser.stringValue("newFile");
+  
+  fProduce = new TFile(newFileName.c_str(),"RECREATE");
+  copyFiles(parser, f, fProduce);//new TFile(parser.stringValue("inputFile").c_str()+"SVFit","UPDATE");
+  fProduce = new TFile(newFileName.c_str(),"UPDATE");
+  std::cout<<"listing the directories================="<<std::endl;
+  fProduce->ls();
+  readdir(fProduce,parser,TreeToUse,parser.doubleValue("doES"),parser.doubleValue("isWJets"),
+          parser.doubleValue("metType"),parser.doubleValue("tesSize"));
+  
+  fProduce->Close();
+  f->Close();
 } 
 
 
@@ -838,17 +829,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
      
         if( channel == "mt" || channel == "et" ) {
           
-          float shiftTau=1.0;
-          if (gen_match_2==5 && decayMode2==0) shiftTau=0.982;
-          if (gen_match_2==5 && decayMode2==1) shiftTau=1.010;
-          if (gen_match_2==5 && decayMode2==10) shiftTau=1.004;
-          pt2 = pt2 * shiftTau;
-          double dx2, dy2;
-          dx2 = pt2 * TMath::Cos( phi2 ) * (( 1. / shiftTau ) - 1.);
-          dy2 = pt2 * TMath::Sin( phi2 ) * (( 1. / shiftTau ) - 1.);
-          metcorr_ex = metcorr_ex + dx2;
-          metcorr_ey = metcorr_ey + dy2;
-          
           mass2 = m2;
           std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptons{
               classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
@@ -863,23 +843,18 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 
           // MET systematics
           std::cout << "MET Unclustered Energy Up   ---  ";
-          metcorrUncUp_ex = metcorrUncUp_ex + dx2;
-          metcorrUncUp_ey = metcorrUncUp_ey + dy2;
           runSVFit(measuredTauLeptons, metcorrUncUp_ex, metcorrUncUp_ey, covMET, 0, svFitMass_UncMet_UP, svFitPt_UncMet_UP, svFitEta_UncMet_UP, 
               svFitPhi_UncMet_UP, svFitMET_UncMet_UP, svFitTransverseMass_UncMet_UP, tau1_UncMet_up, tau2_UncMet_up);
+
           std::cout << "MET Unclustered Energy Down ---  ";
-          metcorrUncDown_ex = metcorrUncDown_ex + dx2;
-          metcorrUncDown_ey = metcorrUncDown_ey + dy2;
           runSVFit(measuredTauLeptons, metcorrUncDown_ex, metcorrUncDown_ey, covMET, 0, svFitMass_UncMet_DOWN, svFitPt_UncMet_DOWN, svFitEta_UncMet_DOWN, 
               svFitPhi_UncMet_DOWN, svFitMET_UncMet_DOWN, svFitTransverseMass_UncMet_DOWN, tau1_UncMet_down, tau2_UncMet_down);
+
           std::cout << "MET Clustered Energy Up     ---  ";
-          metcorrClusteredUp_ex = metcorrClusteredUp_ex + dx2;
-          metcorrClusteredUp_ey = metcorrClusteredUp_ey + dy2;
           runSVFit(measuredTauLeptons, metcorrClusteredUp_ex, metcorrClusteredUp_ey, covMET, 0, svFitMass_ClusteredMet_UP, svFitPt_ClusteredMet_UP, 
               svFitEta_ClusteredMet_UP, svFitPhi_ClusteredMet_UP, svFitMET_ClusteredMet_UP, svFitTransverseMass_ClusteredMet_UP, tau1_ClusteredMet_up, tau2_ClusteredMet_up);
+
           std::cout << "MET Clustered Energy Down   ---  ";
-          metcorrClusteredDown_ex = metcorrClusteredDown_ex + dx2;
-          metcorrClusteredDown_ey = metcorrClusteredDown_ey + dy2;
           runSVFit(measuredTauLeptons, metcorrClusteredDown_ex, metcorrClusteredDown_ey, covMET, 0, svFitMass_ClusteredMet_DOWN, svFitPt_ClusteredMet_DOWN, 
               svFitEta_ClusteredMet_DOWN, svFitPhi_ClusteredMet_DOWN, svFitMET_ClusteredMet_DOWN, svFitTransverseMass_ClusteredMet_DOWN, tau1_ClusteredMet_down, tau2_ClusteredMet_down);
 
@@ -903,14 +878,22 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
           if(doES) {
             
             // corrections only need to be done once
-            float ES_UP( tesUP ), ES_DOWN( tesDOWN ); // Energy scale
-            double pt_UP( pt2 * ES_UP ), pt_DOWN( pt2 * ES_DOWN ); // shift tau pT by energy scale
-            double dx_UP( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP ) - 1.) ),
-                   dy_UP( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP ) - 1.) ),
+            float ES_UP( 1. ), ES_DOWN( 1. ); // shift TES
+            if (gen_match_2 == 5) { // 0.6% uncertainty on hadronic tau
+              ES_UP = 1.006;
+              ES_DOWN = 0.994;
+            } else if (gen_match_2 < 5) { // 1.0% uncertainty on gen matched ele/mu
+              ES_UP = 1.01;
+              ES_DOWN = 0.99;
+            }
+            
+            double pt_UP  ( pt2 * ES_UP ), pt_DOWN( pt2 * ES_DOWN ); // shift tau pT by energy scale
+            double dx_UP  ( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP ) - 1.) ),
+                   dy_UP  ( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP ) - 1.) ),
                    dx_DOWN( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN ) - 1.) ),
                    dy_DOWN( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN ) - 1.) ); 
-            double metcorr_ex_UP( metcorr_ex + dx_UP ), 
-                   metcorr_ey_UP( metcorr_ey + dy_UP ),
+            double metcorr_ex_UP  ( metcorr_ex + dx_UP ), 
+                   metcorr_ey_UP  ( metcorr_ey + dy_UP ),
                    metcorr_ex_DOWN( metcorr_ex + dx_DOWN ),
                    metcorr_ey_DOWN( metcorr_ey + dy_DOWN );
 
@@ -931,7 +914,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             /////////////////////////////
 
             // all tau shift up
-            if (gen_match_2 == 5) {
+            if (gen_match_2 < 6) {
               std::cout << "Tau shift up" << std::endl;
               runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, 
                     svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
@@ -966,11 +949,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM1 shifted up
             if (gen_match_2 == 5 && decayMode2 == 1) {
               std::cout << "DM1 shift up" << std::endl;
-              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
-                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                  classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
-              };
-
               runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, 
                     svFitEta_DM1_UP, svFitPhi_DM1_UP, svFitMET_DM1_UP, svFitTransverseMass_DM1_UP, tau1_DM1_up, tau2_DM1_up);
             } else {
@@ -987,11 +965,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM10 shifted up
             if (gen_match_2 == 5 && decayMode2 == 10) {
               std::cout << "DM10 shift up" << std::endl;
-              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
-                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                  classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
-              };
-
               runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, 
                     svFitEta_DM10_UP, svFitPhi_DM10_UP, svFitMET_DM10_UP, svFitTransverseMass_DM10_UP, tau1_DM10_up, tau2_DM10_up);
             } else {
@@ -1010,7 +983,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             ///////////////////////////////
 
             // all tau shift down
-            if (gen_match_2 == 5) {
+            if (gen_match_2 < 6) {
               std::cout << "Tau shift down" << std::endl;
               runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, 
                     svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
@@ -1030,7 +1003,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
               std::cout << "DM0 shift down" << std::endl;
               runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM0_DOWN, svFitPt_DM0_DOWN, 
                     svFitEta_DM0_DOWN, svFitPhi_DM0_DOWN, svFitMET_DM0_DOWN, svFitTransverseMass_DM0_DOWN, tau1_DM0_down, tau2_DM0_down);
-
             } else {
               svFitMass_DM0_DOWN=svFitMass;
               svFitPt_DM0_DOWN=svFitPt;
@@ -1045,11 +1017,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM1 shifted down
             if (gen_match_2 == 5 && decayMode2 == 1) {
               std::cout << "DM1 shift down" << std::endl;
-              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
-                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                  classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
-              };
-
               runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, 
                     svFitEta_DM1_DOWN, svFitPhi_DM1_DOWN, svFitMET_DM1_DOWN, svFitTransverseMass_DM1_DOWN, tau1_DM1_down, tau2_DM1_down);
             } else {
@@ -1066,11 +1033,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // tau DM10 shifted down
             if (gen_match_2 == 5 && decayMode2 == 10) {
               std::cout << "DM10 shift down" << std::endl;
-              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
-                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                  classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
-              };
-
               runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, 
                     svFitEta_DM10_DOWN, svFitPhi_DM10_DOWN, svFitMET_DM10_DOWN, svFitTransverseMass_DM10_DOWN, tau1_DM10_down, tau2_DM10_down);
             } else {
@@ -1082,66 +1044,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
               svFitTransverseMass_DM10_DOWN=svFitTransverseMass;
               tau1_DM10_down = tau1;
               tau2_DM10_down = tau2;
-            }
-
-            if (gen_match_2<=5){
-              float ES_UP_scale=1.0; // this value is for jet -> tau fakes
-              if (gen_match_2<5) ES_UP_scale=1.01; // for gen matched ele/muon
-              if (gen_match_2==5) ES_UP_scale=tesUP; // for real taus
-              double pt2_UP;
-              pt2_UP = pt2 * ES_UP_scale;
-              double metcorr_ex_UP, metcorr_ey_UP;
-              double dx2_UP, dy2_UP;
-              dx2_UP = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
-              dy2_UP = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP_scale ) - 1.);
-              metcorr_ex_UP = metcorr_ex + dx2_UP;
-              metcorr_ey_UP = metcorr_ey + dy2_UP;
-              
-              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
-                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
-                  classic_svFit::MeasuredTauLepton(decayType2,  pt2_UP, eta2, phi2,  mass2, decayMode2)
-              };
-              
-              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
-            } else {
-              svFitMass_UP=svFitMass;
-              svFitPt_UP=svFitPt;
-              svFitEta_UP=svFitEta;
-              svFitPhi_UP=svFitPhi;
-              svFitMET_UP=svFitMET;
-              svFitTransverseMass_UP=svFitTransverseMass;
-              tau1_up = tau1;
-              tau2_up = tau2;
-            }
-            
-            // Second ES Down, x 0.97
-            if (gen_match_2<=5){
-              float ES_DOWN_scale=1.0; // jet
-              if (gen_match_2==5) ES_DOWN_scale=tesDOWN; // tau
-              if (gen_match_2<5) ES_DOWN_scale=0.990;  // elec/mu
-              double pt2_DOWN;
-              pt2_DOWN = pt2 * ES_DOWN_scale;
-              double metcorr_ex_DOWN, metcorr_ey_DOWN;
-              double dx2_DOWN, dy2_DOWN;
-              dx2_DOWN = pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
-              dy2_DOWN = pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN_scale ) - 1.);
-              metcorr_ex_DOWN = metcorr_ex + dx2_DOWN;
-              metcorr_ey_DOWN = metcorr_ey + dy2_DOWN;
-              
-              std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN;          
-              measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1));
-              measuredTauLeptonsDOWN.push_back(classic_svFit::MeasuredTauLepton(decayType2,  pt2_DOWN, eta2, phi2,  mass2, decayMode2));
-              
-              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
-            } else {
-              svFitMass_DOWN=svFitMass;
-              svFitPt_DOWN=svFitPt;
-              svFitEta_DOWN=svFitEta;
-              svFitPhi_DOWN=svFitPhi;
-              svFitMET_DOWN=svFitMET;
-              svFitTransverseMass_DOWN=svFitTransverseMass;
-              tau1_down = tau1;
-              tau2_down = tau2;
             }
           } // end doES
         } // eTau / muTau

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -880,8 +880,8 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
             // corrections only need to be done once
             float ES_UP( 1. ), ES_DOWN( 1. ); // shift TES
             if (gen_match_2 == 5) { // 0.6% uncertainty on hadronic tau
-              ES_UP = 1.006;
-              ES_DOWN = 0.994;
+              ES_UP = 1.012;
+              ES_DOWN = 0.988;
             } else if (gen_match_2 < 5) { // 1.0% uncertainty on gen matched ele/mu
               ES_UP = 1.01;
               ES_DOWN = 0.99;

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -19,8 +19,6 @@
 #include "TauAnalysis/ClassicSVfit/interface/MeasuredTauLepton.h"
 #include "TauAnalysis/ClassicSVfit/interface/svFitHistogramAdapter.h"
 
-#include "HTT-utilities/RecoilCorrections/interface/RecoilCorrector.h"
-
 #include "TFile.h"
 #include "TTree.h"
 #include "TH1.h"
@@ -37,7 +35,7 @@
 ClassicSVfit svfitAlgorithm;
 
 void copyFiles( optutl::CommandLineParser parser, TFile* fOld, TFile* fNew) ;
-void readdir(TDirectory *dir, optutl::CommandLineParser parser,  char TreeToUse[], int recoilType, int doES, int isWJets, int metType, double tesSize) ;
+void readdir(TDirectory *dir, optutl::CommandLineParser parser,  char TreeToUse[], int doES, int isWJets, int metType, double tesSize) ;
 void CopyFile(const char *fname, optutl::CommandLineParser parser);
 void CopyDir(TDirectory *source,optutl::CommandLineParser parser);
 
@@ -54,7 +52,6 @@ int main (int argc, char* argv[])
   parser.addOption("newFile",optutl::CommandLineParser::kString,"newFile","newFile.root");
   parser.addOption("inputFile",optutl::CommandLineParser::kString,"input File");
   parser.addOption("newOutputFile",optutl::CommandLineParser::kDouble,"New Output File",0.0);
-  parser.addOption("recoilType",optutl::CommandLineParser::kDouble,"recoilType",0.0);
   parser.addOption("doES",optutl::CommandLineParser::kDouble,"doES",0.0);
   parser.addOption("isWJets",optutl::CommandLineParser::kDouble,"isWJets",0.0);
   parser.addOption("metType",optutl::CommandLineParser::kDouble,"metType",-1.0); // 1 = mvamet, -1 = pf met
@@ -64,7 +61,6 @@ int main (int argc, char* argv[])
   
   std::cout << "EXTRA COMMANDS:"
 	    << "\n --- numEvents: " << parser.integerValue("numEvents")
-	    << "\n --- recoilType: " << parser.doubleValue("recoilType")
 	    << "\n --- doES: " << parser.doubleValue("doES")
 	    << "\n --- isWJets: " << parser.doubleValue("isWJets")
 	    << "\n --- metType: " << parser.doubleValue("metType")
@@ -90,7 +86,7 @@ int main (int argc, char* argv[])
     fProduce = new TFile(newFileName.c_str(),"UPDATE");
     std::cout<<"listing the directories================="<<std::endl;
     fProduce->ls();
-    readdir(fProduce,parser,TreeToUse,parser.doubleValue("recoilType"),parser.doubleValue("doES"),
+    readdir(fProduce,parser,TreeToUse,parser.doubleValue("doES"),
             parser.doubleValue("isWJets"),parser.doubleValue("metType"),parser.doubleValue("tesSize"));
     
     fProduce->Close();
@@ -98,7 +94,7 @@ int main (int argc, char* argv[])
   }
   else{
     TFile *f = new TFile(parser.stringValue("inputFile").c_str(),"UPDATE");
-    readdir(f,parser,TreeToUse,parser.doubleValue("recoilType"),parser.doubleValue("doES"),
+    readdir(f,parser,TreeToUse,parser.doubleValue("doES"),
             parser.doubleValue("isWJets"),parser.doubleValue("metType"),parser.doubleValue("tesSize"));
     f->Close();
   }
@@ -107,7 +103,7 @@ int main (int argc, char* argv[])
 } 
 
 
-void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[], int recoilType, int doES, int isWJets, int metType, double tesSize) 
+void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[], int doES, int isWJets, int metType, double tesSize) 
 {
   
   TLorentzVector tau1, tau2;
@@ -117,17 +113,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
   // down systematics
   TLorentzVector tau1_down, tau1_DM0_down, tau1_DM1_down, tau1_DM10_down, tau1_UncMet_down, tau1_ClusteredMet_down;
   TLorentzVector tau2_down, tau2_DM0_down, tau2_DM1_down, tau2_DM10_down, tau2_UncMet_down, tau2_ClusteredMet_down;
-  
-  std::string recoilFileName = "HTT-utilities/RecoilCorrections/data/TypeI-PFMet_Run2016BtoH.root";
-  if(recoilType == 1) { //amc@nlo
-    std::cout << "Alexei no long specified MG vs. AMC@NLO, so use recoilType = 2" << std::endl;
-    return; }
-  if(recoilType == 2 && metType == 1) { // mva met (Alexei no long specified MG vs. AMC@NLO)
-    std::cout << "Alexei does not provide full 2016 data recoil corrections for Mva Met\n\n" << std::endl;
-    std::cout << "Using ICHEP Mva Met corrections\n\n" << std::endl;
-    recoilFileName = "HTT-utilities/RecoilCorrections/data/MvaMET_2016BCD.root";}
-  if(recoilType == 2 && metType == -1) { // pf met (Alexei no long specified MG vs. AMC@NLO)
-    recoilFileName = "HTT-utilities/RecoilCorrections/data/TypeI-PFMet_Run2016BtoH.root";}
   
   classic_svFit::MeasuredTauLepton::kDecayType decayType1 = classic_svFit::MeasuredTauLepton::kUndefinedDecayType;
   classic_svFit::MeasuredTauLepton::kDecayType decayType2 = classic_svFit::MeasuredTauLepton::kUndefinedDecayType; 
@@ -156,7 +141,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       dir->cd(key->GetName());
       TDirectory *subdir = gDirectory;
       sprintf(TreeToUse,"%s",key->GetName());
-      readdir(subdir,parser,TreeToUse,parser.doubleValue("recoilType"),parser.doubleValue("doES"),
+      readdir(subdir,parser,TreeToUse,parser.doubleValue("doES"),
 	      parser.doubleValue("isWJets"),parser.doubleValue("metType"),parser.doubleValue("tesSize"));
       
       dirsav->cd();
@@ -790,12 +775,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 	t->SetBranchAddress("metphi_JESUp", &clusteredMetPhiUp);
 	t->SetBranchAddress("metphi_JESDown", &clusteredMetPhiDown);
       }
-
-      // use this RooT file when running on aMC@NLO DY and W+Jets MC samples
-      RecoilCorrector* recoilCorrector = new RecoilCorrector(recoilFileName);
-      if (metType == 1) std::cout<<"MetType: MvaMet"<<std::endl;
-      if (metType == -1) std::cout<<"MetType: PF Met"<<std::endl;
-      std::cout<<"recoiltype "<<recoilType<<" recoilFileName "<<recoilFileName<<std::endl;
       
       printf("Found tree -> weighting\n");
     
@@ -807,15 +786,6 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
       for(Int_t i=0;i<nevents;++i){
 	t->GetEntry(i);
 
-         //Recoil Correction time
-         // Correct WJets recoil for faked lepton / extra jet
-         int recoilNJets;
-         if(isWJets) {
-            recoilNJets = njets + 1;
-            std::cout << " - njets: " << njets << " recoilNJets: " << recoilNJets << std::endl;
-         }
-         else recoilNJets = njets;
-	 
          // Using PF Met or Mva Met?
          if (metType == 1) { // 1 = Mva Met
 	   TMet.SetPtEtaPhiM(mvamet,0,mvametphi,0);
@@ -847,90 +817,16 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 	   covMET[1][1] =  pfCovMatrix11;
          } // pf met
 	 
-         // Do recoil corrections if requested
-         if(recoilType != 0){
-	   // Alexie shows that corrections via quantile mapping provide best results
-	   // for mva met and pf met, so
-	   // use that as the defaul.  People can switch if they want below
-	   //
-	   // RecoilCorrector::Correct == Quantile Mapping
-	   // RecoilCorrector::CorrectByMeanResolution == By Mean Res
-	   
-	   //recoilCorrector->Correct(
-	   recoilCorrector->CorrectByMeanResolution( // This method is faster (Alexei)
-						    measuredMETx, // uncorrected mva met px (float)
-						    measuredMETy, // uncorrected mva met py (float)
-						    genPx, // generator Z/W/Higgs px (float)
-						    genPy, // generator Z/W/Higgs py (float)
-						    visPx, // generator visible Z/W/Higgs px (float)
-						    visPy, // generator visible Z/W/Higgs py (float)
-						    recoilNJets,  // number of jets (hadronic jet multiplicity) (int)
-						    metcorr_ex, // corrected met px (float)
-						    metcorr_ey  // corrected met py (float)
-						     );
-	   // Shifted MET unc Up
-	   recoilCorrector->CorrectByMeanResolution( // This method is faster (Alexei)
-						    uncMetUpMETx, // uncorrected mva met px (float)
-						    uncMetUpMETy, // uncorrected mva met py (float)
-						    genPx, // generator Z/W/Higgs px (float)
-						    genPy, // generator Z/W/Higgs py (float)
-						    visPx, // generator visible Z/W/Higgs px (float)
-						    visPy, // generator visible Z/W/Higgs py (float)
-						    recoilNJets,  // number of jets (hadronic jet multiplicity) (int)
-						    metcorrUncUp_ex, // corrected met px (float)
-						    metcorrUncUp_ey  // corrected met py (float)
-						     );
-	   // Shifted MET unc Down
-	   recoilCorrector->CorrectByMeanResolution( // This method is faster (Alexei)
-						    uncMetDownMETx, // uncorrected mva met px (float)
-						    uncMetDownMETy, // uncorrected mva met py (float)
-						    genPx, // generator Z/W/Higgs px (float)
-						    genPy, // generator Z/W/Higgs py (float)
-						    visPx, // generator visible Z/W/Higgs px (float)
-						    visPy, // generator visible Z/W/Higgs py (float)
-						    recoilNJets,  // number of jets (hadronic jet multiplicity) (int)
-						    metcorrUncDown_ex, // corrected met px (float)
-						    metcorrUncDown_ey  // corrected met py (float)
-						     );
-	   // Shifted MET clustered Up
-	   recoilCorrector->CorrectByMeanResolution( // This method is faster (Alexei)
-						    clusteredMetUpMETx, // uncorrected mva met px (float)
-						    clusteredMetUpMETy, // uncorrected mva met py (float)
-						    genPx, // generator Z/W/Higgs px (float)
-						    genPy, // generator Z/W/Higgs py (float)
-						    visPx, // generator visible Z/W/Higgs px (float)
-						    visPy, // generator visible Z/W/Higgs py (float)
-						    recoilNJets,  // number of jets (hadronic jet multiplicity) (int)
-						    metcorrClusteredUp_ex, // corrected met px (float)
-						    metcorrClusteredUp_ey  // corrected met py (float)
-						     );
-	   // Shifted MET clustered Down
-	   recoilCorrector->CorrectByMeanResolution( // This method is faster (Alexei)
-						    clusteredMetDownMETx, // uncorrected mva met px (float)
-						    clusteredMetDownMETy, // uncorrected mva met py (float)
-						    genPx, // generator Z/W/Higgs px (float)
-						    genPy, // generator Z/W/Higgs py (float)
-						    visPx, // generator visible Z/W/Higgs px (float)
-						    visPy, // generator visible Z/W/Higgs py (float)
-						    recoilNJets,  // number of jets (hadronic jet multiplicity) (int)
-						    metcorrClusteredDown_ex, // corrected met px (float)
-						    metcorrClusteredDown_ey  // corrected met py (float)
-						     );
-           std::cout << " - MEASURED:  met_ex: " << measuredMETx << "  met_ey: " << measuredMETy << std::endl;
-           std::cout << " - CORRECTED: met_ex: " << metcorr_ex << "  met_ey: " << metcorr_ey << std::endl;
-	 }
-	 else{
-           metcorr_ex = measuredMETx;
-           metcorr_ey = measuredMETy;
-           metcorrUncUp_ex = uncMetUpMETx;
-           metcorrUncUp_ey = uncMetUpMETy;
-           metcorrUncDown_ex = uncMetDownMETx;
-           metcorrUncDown_ey = uncMetDownMETy;
-           metcorrClusteredUp_ex = clusteredMetUpMETx;
-           metcorrClusteredUp_ey = clusteredMetUpMETy;
-           metcorrClusteredDown_ex = clusteredMetDownMETx;
-           metcorrClusteredDown_ey = clusteredMetDownMETy;
-	 }
+     metcorr_ex = measuredMETx;
+     metcorr_ey = measuredMETy;
+     metcorrUncUp_ex = uncMetUpMETx;
+     metcorrUncUp_ey = uncMetUpMETy;
+     metcorrUncDown_ex = uncMetDownMETx;
+     metcorrUncDown_ey = uncMetDownMETy;
+     metcorrClusteredUp_ex = clusteredMetUpMETx;
+     metcorrClusteredUp_ey = clusteredMetUpMETy;
+     metcorrClusteredDown_ex = clusteredMetDownMETx;
+     metcorrClusteredDown_ey = clusteredMetDownMETy;
 	 
 	 metcor = TMath::Sqrt( metcorr_ex*metcorr_ex + metcorr_ey*metcorr_ey);
 	 metcorphi = TMath::ATan2( metcorr_ey, metcorr_ex );
@@ -1156,9 +1052,7 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 	   //*****************************************************
 	   // MET SYSTEMATICS
 	   // Taus Pt have been corrected (TEC)
-	   // All 4 mets have recoil corrections already applied
-	   // Still need TEC propagated to shifted, recoil corrected
-	   // METs
+	   // Still need TEC propagated to shifted METs
 	   //*****************************************************
 	   
 	   std::cout << "MET Unclustered Energy Up   ---  ";

--- a/ROOT/bin/SVFitStandAloneFSATauDM.cc
+++ b/ROOT/bin/SVFitStandAloneFSATauDM.cc
@@ -860,8 +860,193 @@ void readdir(TDirectory *dir, optutl::CommandLineParser parser, char TreeToUse[]
 	      runSVFit(measuredTauLeptons, metcorr_ex, metcorr_ey, covMET, 0, 
 	           svFitMass, svFitPt, svFitEta, svFitPhi, svFitMET, svFitTransverseMass, tau1, tau2);
 	      std::cout<<"finished runningSVFit"<<std::endl;
+
+          // TODO: MET Systematics 
 	      
 	      if(doES) {
+            
+            // corrections only need to be done once
+            float ES_UP( tesUP ), ES_DOWN( tesDOWN ); // Energy scale
+            double pt_UP( pt2 * ES_UP ), pt_DOWN( pt2 * ES_DOWN ); // shift tau pT by energy scale
+            double dx_UP( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_UP ) - 1.) ),
+                   dy_UP( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_UP ) - 1.) ),
+                   dx_DOWN( pt2 * TMath::Cos( phi2 ) * (( 1. / ES_DOWN ) - 1.) ),
+                   dy_DOWN( pt2 * TMath::Sin( phi2 ) * (( 1. / ES_DOWN ) - 1.) ); 
+            double metcorr_ex_UP( metcorr_ex + dx_UP ), 
+                   metcorr_ey_UP( metcorr_ey + dy_UP ),
+                   metcorr_ex_DOWN( metcorr_ex + dx_DOWN ),
+                   metcorr_ey_DOWN( metcorr_ey + dy_DOWN );
+
+            // leptons shifted up
+            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+                classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+                classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
+            };
+
+            // leptons shifted down
+            std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
+                classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+                classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
+            };
+          
+            /////////////////////////////
+            // All upward shifts below //
+            /////////////////////////////
+
+            // all tau shift up
+            if (gen_match_2 == 5) {
+              std::cout << "Tau shift up" << std::endl;
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_UP, svFitPt_UP, 
+                    svFitEta_UP, svFitPhi_UP, svFitMET_UP, svFitTransverseMass_UP, tau1_up, tau2_up);
+            } else {
+              svFitMass_UP=svFitMass;
+              svFitPt_UP=svFitPt;
+              svFitEta_UP=svFitEta;
+              svFitPhi_UP=svFitPhi;
+              svFitMET_UP=svFitMET;
+              svFitTransverseMass_UP=svFitTransverseMass;
+              tau1_up = tau1;
+              tau2_up = tau2;
+            }
+
+            // tau DM0 shifted up
+            if (gen_match_2 == 5 && decayMode2 == 0) {
+              std::cout << "DM0 shift up" << std::endl;
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM0_UP, svFitPt_DM0_UP, 
+                    svFitEta_DM0_UP, svFitPhi_DM0_UP, svFitMET_DM0_UP, svFitTransverseMass_DM0_UP, tau1_DM0_up, tau2_DM0_up);
+
+            } else {
+              svFitMass_DM0_UP=svFitMass;
+              svFitPt_DM0_UP=svFitPt;
+              svFitEta_DM0_UP=svFitEta;
+              svFitPhi_DM0_UP=svFitPhi;
+              svFitMET_DM0_UP=svFitMET;
+              svFitTransverseMass_DM0_UP=svFitTransverseMass;
+              tau1_DM0_up = tau1;
+              tau2_DM0_up = tau2;
+            }
+
+            // tau DM1 shifted up
+            if (gen_match_2 == 5 && decayMode2 == 1) {
+              std::cout << "DM1 shift up" << std::endl;
+	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+	              classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
+              };
+
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM1_UP, svFitPt_DM1_UP, 
+                    svFitEta_DM1_UP, svFitPhi_DM1_UP, svFitMET_DM1_UP, svFitTransverseMass_DM1_UP, tau1_DM1_up, tau2_DM1_up);
+            } else {
+              svFitMass_DM1_UP=svFitMass;
+              svFitPt_DM1_UP=svFitPt;
+              svFitEta_DM1_UP=svFitEta;
+              svFitPhi_DM1_UP=svFitPhi;
+              svFitMET_DM1_UP=svFitMET;
+              svFitTransverseMass_DM1_UP=svFitTransverseMass;
+              tau1_DM1_up = tau1;
+              tau2_DM1_up = tau2;
+            }
+
+            // tau DM10 shifted up
+            if (gen_match_2 == 5 && decayMode2 == 10) {
+              std::cout << "DM10 shift up" << std::endl;
+	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsUP{
+                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+	              classic_svFit::MeasuredTauLepton(decayType2,  pt_UP, eta2, phi2,  mass2, decayMode2)
+              };
+
+              runSVFit(measuredTauLeptonsUP, metcorr_ex_UP, metcorr_ey_UP, covMET, 0, svFitMass_DM10_UP, svFitPt_DM10_UP, 
+                    svFitEta_DM10_UP, svFitPhi_DM10_UP, svFitMET_DM10_UP, svFitTransverseMass_DM10_UP, tau1_DM10_up, tau2_DM10_up);
+            } else {
+              svFitMass_DM10_UP=svFitMass;
+              svFitPt_DM10_UP=svFitPt;
+              svFitEta_DM10_UP=svFitEta;
+              svFitPhi_DM10_UP=svFitPhi;
+              svFitMET_DM10_UP=svFitMET;
+              svFitTransverseMass_DM10_UP=svFitTransverseMass;
+              tau1_DM10_up = tau1;
+              tau2_DM10_up = tau2;
+            }
+
+            ///////////////////////////////
+            // All downward shifts below //
+            ///////////////////////////////
+
+            // all tau shift down
+            if (gen_match_2 == 5) {
+              std::cout << "Tau shift down" << std::endl;
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DOWN, svFitPt_DOWN, 
+                    svFitEta_DOWN, svFitPhi_DOWN, svFitMET_DOWN, svFitTransverseMass_DOWN, tau1_down, tau2_down);
+            } else {
+              svFitMass_DOWN=svFitMass;
+              svFitPt_DOWN=svFitPt;
+              svFitEta_DOWN=svFitEta;
+              svFitPhi_DOWN=svFitPhi;
+              svFitMET_DOWN=svFitMET;
+              svFitTransverseMass_DOWN=svFitTransverseMass;
+              tau1_down = tau1;
+              tau2_down = tau2;
+            }
+
+            // tau DM0 shifted down
+            if (gen_match_2 == 5 && decayMode2 == 0) {
+              std::cout << "DM0 shift down" << std::endl;
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM0_DOWN, svFitPt_DM0_DOWN, 
+                    svFitEta_DM0_DOWN, svFitPhi_DM0_DOWN, svFitMET_DM0_DOWN, svFitTransverseMass_DM0_DOWN, tau1_DM0_down, tau2_DM0_down);
+
+            } else {
+              svFitMass_DM0_DOWN=svFitMass;
+              svFitPt_DM0_DOWN=svFitPt;
+              svFitEta_DM0_DOWN=svFitEta;
+              svFitPhi_DM0_DOWN=svFitPhi;
+              svFitMET_DM0_DOWN=svFitMET;
+              svFitTransverseMass_DM0_DOWN=svFitTransverseMass;
+              tau1_DM0_down = tau1;
+              tau2_DM0_down = tau2;
+            }
+
+            // tau DM1 shifted down
+            if (gen_match_2 == 5 && decayMode2 == 1) {
+              std::cout << "DM1 shift down" << std::endl;
+	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
+                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+	              classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
+              };
+
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM1_DOWN, svFitPt_DM1_DOWN, 
+                    svFitEta_DM1_DOWN, svFitPhi_DM1_DOWN, svFitMET_DM1_DOWN, svFitTransverseMass_DM1_DOWN, tau1_DM1_down, tau2_DM1_down);
+            } else {
+              svFitMass_DM1_DOWN=svFitMass;
+              svFitPt_DM1_DOWN=svFitPt;
+              svFitEta_DM1_DOWN=svFitEta;
+              svFitPhi_DM1_DOWN=svFitPhi;
+              svFitMET_DM1_DOWN=svFitMET;
+              svFitTransverseMass_DM1_DOWN=svFitTransverseMass;
+              tau1_DM1_down = tau1;
+              tau2_DM1_down = tau2;
+            }
+
+            // tau DM10 shifted down
+            if (gen_match_2 == 5 && decayMode2 == 10) {
+              std::cout << "DM10 shift down" << std::endl;
+	          std::vector<classic_svFit::MeasuredTauLepton> measuredTauLeptonsDOWN{
+                  classic_svFit::MeasuredTauLepton(decayType1, pt1, eta1,  phi1, mass1),
+	              classic_svFit::MeasuredTauLepton(decayType2,  pt_DOWN, eta2, phi2,  mass2, decayMode2)
+              };
+
+              runSVFit(measuredTauLeptonsDOWN, metcorr_ex_DOWN, metcorr_ey_DOWN, covMET, 0, svFitMass_DM10_DOWN, svFitPt_DM10_DOWN, 
+                    svFitEta_DM10_DOWN, svFitPhi_DM10_DOWN, svFitMET_DM10_DOWN, svFitTransverseMass_DM10_DOWN, tau1_DM10_down, tau2_DM10_down);
+            } else {
+              svFitMass_DM10_DOWN=svFitMass;
+              svFitPt_DM10_DOWN=svFitPt;
+              svFitEta_DM10_DOWN=svFitEta;
+              svFitPhi_DM10_DOWN=svFitPhi;
+              svFitMET_DM10_DOWN=svFitMET;
+              svFitTransverseMass_DM10_DOWN=svFitTransverseMass;
+              tau1_DM10_down = tau1;
+              tau2_DM10_down = tau2;
+            }
+
 	        
 	        if (gen_match_2<=5){
 	          float ES_UP_scale=1.0; // this value is for jet -> tau fakes

--- a/test/metaSubmitter.py
+++ b/test/metaSubmitter.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description="run on a directory containing directories containing the skimmed ntuples")
+parser.add_argument('-d', '--sampledir', action = 'store', help = 'path to the directory')
+parser.add_argument('-p', '--prefix', action = 'store', help = 'name to prefix all directories')
+args = parser.parse_args()
+
+sampledir = args.sampledir
+prefix = args.prefix
+
+dirlist = ['%s%s' % (sampledir, sample) for sample in os.listdir(sampledir)]
+for idir in dirlist:
+  iswj = 0
+  if 'WJets' in idir:
+    iswj = 1
+#  print('python svFitSubmitter.py -sd %s -es=1 -iswj=%i -mt=-1 --jobName %s/svfit_dir_%s' % (idir, iswj, prefix, idir.split('/')[-1]))
+  subprocess.call('python svFitSubmitter.py -sd %s -es=1 -iswj=%i -mt=-1 --jobName %s/svfit_dir_%s' % (idir, iswj, prefix, idir.split('/')[-1]), shell=True)

--- a/test/svFitSubmitter.py
+++ b/test/svFitSubmitter.py
@@ -97,7 +97,7 @@ def main(argv=None):
     bash_name = '%s/%s_%i_%s.sh' % (dag_dir+'inputs', channel, period, sample_name)
 #SVFitStandAlone outputFile="WZ.root" newOutputFile=1.0 newFile="none"
     bashScript = "#!/bin/bash\n value=$(<$INPUT)\n echo \"$value\"\n"
-    bashScript += '$CMSSW_BASE/bin/$SCRAM_ARCH/SVFitStandAloneFSATauDM inputfile=$value newOutputFile=1.0 newFile=\'$OUTPUT\'' #% (channel, sample_name, period)
+    bashScript += '$CMSSW_BASE/bin/$SCRAM_ARCH/SVFitStandAloneFSATauDM inputfile=$value newFile=\'$OUTPUT\'' #% (channel, sample_name, period)
     if args.recoilType : recoilType = "recoilType="+args.recoilType
     else : recoilType = ''
     if args.doES : doES = "doES="+args.doES


### PR DESCRIPTION
In mutau channel, tree name is mutau_tree. Because we are using Cécile's code everywhere in mutau, I kept it to avoid any potential conflictions.